### PR TITLE
✨feat : Input 공통컴포넌트

### DIFF
--- a/app/(route)/setting/profile/page.tsx
+++ b/app/(route)/setting/profile/page.tsx
@@ -3,6 +3,8 @@
 import classNames from "classnames";
 import Image from "next/image";
 import { ChangeEvent, KeyboardEvent, MouseEvent, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import InputFile from "@/components/input/InputFile";
 import defaultImg from "@/public/icon/icon_add-image_gray.svg";
 
 const ProfilePage = () => {
@@ -44,12 +46,20 @@ const ProfilePage = () => {
     }
   };
 
+  const { getValues, control } = useForm({
+    defaultValues: {
+      profileImage: "",
+    },
+  });
+  console.log(getValues("profileImage"));
+
   return (
     <div className="flex flex-col gap-24">
       <div className="flex flex-col gap-8">
         <p className="text-16">프로필 사진</p>
         <div className="flex justify-center">
-          <label onKeyDown={handleKeyDown} className="relative h-100 w-100 cursor-pointer rounded-full" tabIndex={0}>
+          <InputFile control={control} name="profileImage" />
+          {/* <label onKeyDown={handleKeyDown} className="relative h-100 w-100 cursor-pointer rounded-full" tabIndex={0}>
             <input ref={input} onClick={handleFileDelete} onChange={handleFileChange} type="file" className="hidden" accept="image/*" />
             <Image
               src={value.profileImage || defaultImg}
@@ -57,8 +67,9 @@ const ProfilePage = () => {
               alt="이미지 추가 버튼"
               className={classNames("rounded-full object-cover", { "hover:brightness-50": value.profileImage })}
             />
-          </label>
+          </label> */}
         </div>
+        <button onClick={() => console.log(getValues("profileImage"))}>확인</button>
       </div>
       <div className="flex flex-col gap-8">
         <p className="text-16">닉네임</p>

--- a/app/(route)/signup/_components/AccountInfo.tsx
+++ b/app/(route)/signup/_components/AccountInfo.tsx
@@ -1,4 +1,5 @@
 import { useFormContext } from "react-hook-form";
+import InputText from "@/components/input/InputText";
 import { ERROR_MESSAGES, REG_EXP } from "../../../_utils/signupValidation";
 import { SignUpFormValues } from "../page";
 import InputContainer from "./InputContainer";
@@ -11,7 +12,7 @@ export const AccountInfo = ({ onNext }: { onNext: () => void }) => {
   return (
     <div className="flex flex-col gap-24 p-12">
       <p className=" text-16 font-700 text-black">로그인 정보를 입력해주세요</p>
-      <InputContainer
+      <InputText
         control={control}
         name="email"
         autoComplete="username"
@@ -19,7 +20,7 @@ export const AccountInfo = ({ onNext }: { onNext: () => void }) => {
         rules={{ required: ERROR_MESSAGES.email.emailField, pattern: { value: REG_EXP.CHECK_EMAIL, message: ERROR_MESSAGES.email.emailPattern } }}
       >
         이메일
-      </InputContainer>
+      </InputText>
       <InputContainer
         control={control}
         name="password"

--- a/app/_components/input/InputC.tsx
+++ b/app/_components/input/InputC.tsx
@@ -1,0 +1,62 @@
+import classNames from "classnames";
+import Image from "next/image";
+import { ReactNode, useState } from "react";
+import { FieldPath, FieldValues, UseControllerProps, useController } from "react-hook-form";
+
+interface Prop {
+  type?: "text" | "password";
+  children: ReactNode;
+  placeholder?: string;
+  autoComplete?: string;
+  hint?: string;
+  maxLength?: number;
+}
+
+type Function = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(
+  prop: UseControllerProps<TFieldValues, TName> & Prop,
+) => ReactNode;
+
+const InputC: Function = ({ type: initialType, children, placeholder, autoComplete, hint, maxLength, ...control }) => {
+  const { field, fieldState } = useController(control);
+  const [type, setType] = useState(initialType ?? "text");
+
+  const handlePasswordShow = () => {
+    setType((prev) => (prev === "password" ? "text" : "password"));
+  };
+
+  const handleDelete = () => {
+    field.onChange("");
+  };
+
+  return (
+    <div className="relative">
+      <label htmlFor={field.name} className="text-14">
+        {children}
+      </label>
+      <input
+        id={field.name}
+        type={type}
+        placeholder={placeholder ?? "입력해주세요."}
+        autoComplete={autoComplete ?? "off"}
+        {...field}
+        className={`border-solid-gray body1-normal placeholder:text-gray-4 focus:border-purple mt-10 h-48 w-full rounded-md bg-blue-50 p-16 text-14 text-black outline-none `}
+      />
+      {initialType === "password" && (
+        <button onClick={handlePasswordShow} type="button" className="absolute right-0 top-44 h-24 w-24 -translate-x-1/2 -translate-y-1/2">
+          {<Image src={type === "password" ? "/icon/closed-eyes_black.svg" : "/icon/opened-eyes_black.svg"} alt="비밀번호 아이콘" width={16} height={16} />}
+        </button>
+      )}
+      {initialType !== "password" && (
+        <button onClick={handleDelete} type="button" className="absolute right-0 top-44 h-24 w-24 -translate-x-1/2 -translate-y-1/2">
+          <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
+        </button>
+      )}
+      <div className="flex gap-8">
+        {maxLength ? <span className={classNames("mt-4 h-8", { "text-red-500": field.value.length > maxLength })}>{`(${field.value.length}/${maxLength})`}</span> : null}
+        <p className={classNames(`font-normal mt-4 h-8 text-12`, { "text-red-500": fieldState.error, "text-gray-400": !fieldState.error })}>{fieldState?.error?.message || hint}</p>
+      </div>
+    </div>
+  );
+};
+
+export default InputC;

--- a/app/_components/input/InputFile.tsx
+++ b/app/_components/input/InputFile.tsx
@@ -16,7 +16,7 @@ const InputFile: Function = (props) => {
 
   return (
     <label className="relative h-100 w-100 cursor-pointer rounded-full" tabIndex={0}>
-      <input type="file" name={field.name} ref={field.ref} multiple onChange={handleChange} className="hidden" accept="image/*" />
+      <input id={field.name} type="file" name={field.name} ref={field.ref} multiple onChange={handleChange} className="hidden" accept="image/*" />
       <Image src={defaultImg} fill alt="이미지 추가 버튼" className="rounded-full object-cover" />
     </label>
   );

--- a/app/_components/input/InputFile.tsx
+++ b/app/_components/input/InputFile.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+import { ChangeEvent, ReactNode } from "react";
+import { FieldPath, FieldValues, UseControllerProps, useController } from "react-hook-form";
+import defaultImg from "@/public/icon/add-image_gray.svg";
+
+type Function = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(
+  prop: UseControllerProps<TFieldValues, TName>,
+) => ReactNode;
+
+const InputFile: Function = (props) => {
+  const { field } = useController(props);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    field.onChange({ target: { value: e.target.files, name: field.name } });
+  };
+
+  return (
+    <label className="relative h-100 w-100 cursor-pointer rounded-full" tabIndex={0}>
+      <input type="file" name={field.name} ref={field.ref} multiple onChange={handleChange} className="hidden" accept="image/*" />
+      <Image src={defaultImg} fill alt="이미지 추가 버튼" className="rounded-full object-cover" />
+    </label>
+  );
+};
+export default InputFile;

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -16,7 +16,7 @@ type Function = <TFieldValues extends FieldValues = FieldValues, TName extends F
   prop: UseControllerProps<TFieldValues, TName> & Prop,
 ) => ReactNode;
 
-const InputC: Function = ({ type: initialType, children, placeholder, autoComplete, hint, maxLength, ...control }) => {
+const InputText: Function = ({ type: initialType, children, placeholder, autoComplete, hint, maxLength, ...control }) => {
   const { field, fieldState } = useController(control);
   const [type, setType] = useState(initialType ?? "text");
 
@@ -59,4 +59,4 @@ const InputC: Function = ({ type: initialType, children, placeholder, autoComple
   );
 };
 
-export default InputC;
+export default InputText;


### PR DESCRIPTION
## ✏️ 변경사항
- [x] Input 공통컴포넌트 제작

## 📷 스크린샷
### InputText
![image](https://github.com/P1Z7/frontend/assets/78120157/1b8f28ef-1713-4a82-b9c6-15160156cea2)

### InputFile
![image](https://github.com/P1Z7/frontend/assets/78120157/f1445294-fca4-422f-9e3d-cfcad04de83a)


## ✍️ 사용법
### InputText
타입
```ts
interface Prop {
  type?: "text" | "password";
  children: ReactNode;
  placeholder?: string;
  autoComplete?: string;
  hint?: string;
  maxLength?: number;
}
```

```ts
const { control } = useForm();

<InputText
      control={control}
      name=""
      placeholder=""
>
      제목
</InputText>
```

### InputFile
타입
```ts
없
```

```ts
const { control } = useForm();

<InputFile
      control={control}
      name=""
>
      제목
</InputFile>
```

## 🎸 기타
