### PR TITLE
✨ feat: /edit 페이지 로직 구현

### DIFF
--- a/app/(route)/event/[id]/edit/_components/EditContent.tsx
+++ b/app/(route)/event/[id]/edit/_components/EditContent.tsx
@@ -1,0 +1,26 @@
+import DetailInput from "@/(route)/post/_components/_inputs/DetailInput";
+import MainInput from "@/(route)/post/_components/_inputs/MainInput";
+import StarInput from "@/(route)/post/_components/_inputs/StarInput";
+import SubInput from "@/(route)/post/_components/_inputs/SubInput";
+import { PostType } from "@/(route)/post/page";
+import { useFormContext } from "react-hook-form";
+import EditModal from "@/components/modal/EditModal";
+import { useModal } from "@/hooks/useModal";
+
+const EditContent = () => {
+  const { modal, openModal, closeModal } = useModal();
+  const { setValue, getValues } = useFormContext<PostType>();
+
+  return (
+    <>
+      <MainInput setValue={setValue} />
+      <StarInput getValues={getValues} setValue={setValue} />
+      <SubInput getValues={getValues} setValue={setValue} />
+      {/* <DetailInput /> */}
+      <button onClick={() => openModal("endEdit")}>수정 요청</button>
+      {modal === "endEdit" && <EditModal closeModal={closeModal} />}
+    </>
+  );
+};
+
+export default EditContent;

--- a/app/(route)/event/[id]/edit/_components/EditContent.tsx
+++ b/app/(route)/event/[id]/edit/_components/EditContent.tsx
@@ -3,23 +3,36 @@ import MainInput from "@/(route)/post/_components/_inputs/MainInput";
 import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
+import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import EditModal from "@/components/modal/EditModal";
 import { useModal } from "@/hooks/useModal";
 
 const EditContent = () => {
   const { modal, openModal, closeModal } = useModal();
-  const { setValue, getValues } = useFormContext<PostType>();
+  const { setValue, getValues, control, watch } = useFormContext<PostType>();
+  const [imgList, setImgList] = useState<(File | string)[]>([]);
+  const [isCheck, setIsCheck] = useState(false);
+  const { images } = watch();
 
   return (
-    <>
+    <div className="text-16">
       <MainInput setValue={setValue} />
       <StarInput getValues={getValues} setValue={setValue} />
       <SubInput getValues={getValues} setValue={setValue} />
-      {/* <DetailInput /> */}
+      <DetailInput
+        images={images}
+        control={control}
+        isCheck={isCheck}
+        setIsCheck={setIsCheck}
+        imgList={imgList}
+        setImgList={setImgList}
+        getValues={getValues}
+        setValue={setValue}
+      />
       <button onClick={() => openModal("endEdit")}>수정 요청</button>
       {modal === "endEdit" && <EditModal closeModal={closeModal} />}
-    </>
+    </div>
   );
 };
 

--- a/app/(route)/event/[id]/edit/_components/EditContent.tsx
+++ b/app/(route)/event/[id]/edit/_components/EditContent.tsx
@@ -20,8 +20,8 @@ const EditContent = () => {
     formState: { isDirty, defaultValues },
   } = useFormContext<PostType>();
   const [imgList, setImgList] = useState<(File | string)[]>([]);
-  const [isCheck, setIsCheck] = useState(false);
   const { images, address, startDate, endDate, eventType, snsType, gift } = watch();
+  const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
 
   const checkUpdated = () => {
     if (defaultValues?.address !== address) return true;
@@ -41,16 +41,7 @@ const EditContent = () => {
       <MainInput setValue={setValue} />
       <StarInput getValues={getValues} setValue={setValue} />
       <SubInput getValues={getValues} setValue={setValue} />
-      <DetailInput
-        images={images}
-        control={control}
-        isCheck={isCheck}
-        setIsCheck={setIsCheck}
-        imgList={imgList}
-        setImgList={setImgList}
-        getValues={getValues}
-        setValue={setValue}
-      />
+      <DetailInput images={images} control={control} imgList={imgList} setImgList={setImgList} getValues={getValues} setValue={setValue} />
       <button disabled={!isValid} className={classNames("w-full bg-gray-200 p-16", { "bg-yellow-200": isValid })} onClick={() => openModal("endEdit")}>
         수정 요청
       </button>

--- a/app/(route)/event/[id]/edit/_components/EditContent.tsx
+++ b/app/(route)/event/[id]/edit/_components/EditContent.tsx
@@ -3,17 +3,38 @@ import MainInput from "@/(route)/post/_components/_inputs/MainInput";
 import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
+import classNames from "classnames";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import EditModal from "@/components/modal/EditModal";
 import { useModal } from "@/hooks/useModal";
+import { useStore } from "@/store/index";
 
 const EditContent = () => {
   const { modal, openModal, closeModal } = useModal();
-  const { setValue, getValues, control, watch } = useFormContext<PostType>();
+  const {
+    setValue,
+    getValues,
+    control,
+    watch,
+    formState: { isDirty, defaultValues },
+  } = useFormContext<PostType>();
   const [imgList, setImgList] = useState<(File | string)[]>([]);
   const [isCheck, setIsCheck] = useState(false);
-  const { images } = watch();
+  const { images, address, startDate, endDate, eventType, snsType, gift } = watch();
+
+  const checkUpdated = () => {
+    if (defaultValues?.address !== address) return true;
+    if (defaultValues.startDate !== startDate) return true;
+    if (defaultValues.endDate !== endDate) return true;
+    if (defaultValues.eventType !== eventType) return true;
+    if (defaultValues.snsType !== snsType) return true;
+    if (defaultValues?.gift?.length !== gift.length) return true;
+    if (gift.filter((item) => !defaultValues?.gift?.includes(item)).length !== 0) return true;
+    return false;
+  };
+
+  const isValid = (isDirty || checkUpdated()) && isCheck;
 
   return (
     <div className="text-16">
@@ -30,7 +51,9 @@ const EditContent = () => {
         getValues={getValues}
         setValue={setValue}
       />
-      <button onClick={() => openModal("endEdit")}>수정 요청</button>
+      <button disabled={!isValid} className={classNames("w-full bg-gray-200 p-16", { "bg-yellow-200": isValid })} onClick={() => openModal("endEdit")}>
+        수정 요청
+      </button>
       {modal === "endEdit" && <EditModal closeModal={closeModal} />}
     </div>
   );

--- a/app/(route)/event/[id]/edit/_components/EditContent.tsx
+++ b/app/(route)/event/[id]/edit/_components/EditContent.tsx
@@ -4,7 +4,6 @@ import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
 import classNames from "classnames";
-import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import EditModal from "@/components/modal/EditModal";
 import { useModal } from "@/hooks/useModal";
@@ -13,14 +12,10 @@ import { useStore } from "@/store/index";
 const EditContent = () => {
   const { modal, openModal, closeModal } = useModal();
   const {
-    setValue,
-    getValues,
-    control,
     watch,
     formState: { isDirty, defaultValues },
   } = useFormContext<PostType>();
-  const [imgList, setImgList] = useState<(File | string)[]>([]);
-  const { images, address, startDate, endDate, eventType, snsType, gift } = watch();
+  const { address, startDate, endDate, eventType, snsType, gift } = watch();
   const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
 
   const checkUpdated = () => {
@@ -38,10 +33,10 @@ const EditContent = () => {
 
   return (
     <div className="text-16">
-      <MainInput setValue={setValue} />
-      <StarInput getValues={getValues} setValue={setValue} />
-      <SubInput getValues={getValues} setValue={setValue} />
-      <DetailInput images={images} control={control} imgList={imgList} setImgList={setImgList} getValues={getValues} setValue={setValue} />
+      <MainInput />
+      <StarInput />
+      <SubInput />
+      <DetailInput />
       <button disabled={!isValid} className={classNames("w-full bg-gray-200 p-16", { "bg-yellow-200": isValid })} onClick={() => openModal("endEdit")}>
         수정 요청
       </button>

--- a/app/(route)/event/[id]/edit/page.tsx
+++ b/app/(route)/event/[id]/edit/page.tsx
@@ -1,9 +1,6 @@
 "use client";
 
 import GenericForm from "@/(route)/signup/_components/GenericForm";
-import { useEffect } from "react";
-import Header from "@/components/Header";
-import { useStore } from "@/store/index";
 import EditContent from "./_components/EditContent";
 
 const EDIT_MOCKUP_DATA = {
@@ -33,11 +30,11 @@ const Edit = () => {
   //여기서 get하고 이미지들 file 형식으로 변환해서 default 값 설정..?
 
   return (
-    <>
+    <div className="flex flex-col gap-24 p-20 text-16">
       <GenericForm formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
         <EditContent />
       </GenericForm>
-    </>
+    </div>
   );
 };
 

--- a/app/(route)/event/[id]/edit/page.tsx
+++ b/app/(route)/event/[id]/edit/page.tsx
@@ -5,7 +5,7 @@ import EditContent from "./_components/EditContent";
 
 const EDIT_MOCKUP_DATA = {
   group: "에스파",
-  member: ["카리나"],
+  member: ["카리나", "윈터"],
   eventType: "생일카페",
   title: "홍대 ㅁㅁ카페",
   address: "서울 마포구 와우산로 94",
@@ -27,6 +27,8 @@ const EDIT_MOCKUP_DATA = {
 export type EditPostType = typeof EDIT_MOCKUP_DATA;
 
 const Edit = () => {
+  //여기서 get하고 이미지들 file 형식으로 변환해서 default 값 설정..?
+
   return (
     <GenericForm formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
       <EditContent />

--- a/app/(route)/event/[id]/edit/page.tsx
+++ b/app/(route)/event/[id]/edit/page.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import GenericForm from "@/(route)/signup/_components/GenericForm";
+import EditContent from "./_components/EditContent";
+
+const EDIT_MOCKUP_DATA = {
+  group: "에스파",
+  member: ["카리나"],
+  eventType: "생일카페",
+  title: "홍대 ㅁㅁ카페",
+  address: "서울 마포구 와우산로 94",
+  detailAddress: "홍익대학교",
+  startDate: "2024년 1월 9일 화",
+  endDate: "2024년 1월 12일 금",
+  snsId: "@karrrrr",
+  snsType: "트위터",
+  eventUrl: "https://m.cafe.daum.net/zoomin62/GNO8/755003?svc=topRank",
+  gift: ["컵홀더", "포토카드", "스티커", "굿즈"],
+  images: [
+    "https://fandomship.com/data/file/aespa/96d7bf5b058cf52803e681345d7f7847_z8rFhK5X_93129e63980a8f3c265ee5ab64387657ef7deec3.jpg",
+    "https://fandomship.com/data/file/aespa/thumb-d405020284be78411e389d91af05cdb6_IA7RHQcw_be15cbacfc04d16192b27e45bbe6305c6d8df475_835x1181.jpg",
+    "https://fandomship.com/data/file/aespa/thumb-d405020284be78411e389d91af05cdb6_c1VUxAOY_2fb4abd335ccf36c1972868aadb03ed29e557262_835x1181.jpg",
+  ],
+  detailText: "카리나 생일 축하합니다",
+};
+
+export type EditPostType = typeof EDIT_MOCKUP_DATA;
+
+const Edit = () => {
+  return (
+    <GenericForm formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
+      <EditContent />
+    </GenericForm>
+  );
+};
+
+export default Edit;

--- a/app/(route)/event/[id]/edit/page.tsx
+++ b/app/(route)/event/[id]/edit/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import GenericForm from "@/(route)/signup/_components/GenericForm";
+import { useEffect } from "react";
+import Header from "@/components/Header";
+import { useStore } from "@/store/index";
 import EditContent from "./_components/EditContent";
 
 const EDIT_MOCKUP_DATA = {
@@ -10,8 +13,8 @@ const EDIT_MOCKUP_DATA = {
   title: "홍대 ㅁㅁ카페",
   address: "서울 마포구 와우산로 94",
   detailAddress: "홍익대학교",
-  startDate: "2024년 1월 9일 화",
-  endDate: "2024년 1월 12일 금",
+  startDate: "2024-01-09",
+  endDate: "2024-01-12",
   snsId: "@karrrrr",
   snsType: "트위터",
   eventUrl: "https://m.cafe.daum.net/zoomin62/GNO8/755003?svc=topRank",
@@ -30,9 +33,11 @@ const Edit = () => {
   //여기서 get하고 이미지들 file 형식으로 변환해서 default 값 설정..?
 
   return (
-    <GenericForm formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
-      <EditContent />
-    </GenericForm>
+    <>
+      <GenericForm formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
+        <EditContent />
+      </GenericForm>
+    </>
   );
 };
 

--- a/app/(route)/event/[id]/edit/page.tsx
+++ b/app/(route)/event/[id]/edit/page.tsx
@@ -22,7 +22,7 @@ const EDIT_MOCKUP_DATA = {
     "https://fandomship.com/data/file/aespa/thumb-d405020284be78411e389d91af05cdb6_c1VUxAOY_2fb4abd335ccf36c1972868aadb03ed29e557262_835x1181.jpg",
   ],
   detailText: "카리나 생일 축하합니다",
-};
+} as const;
 
 export type EditPostType = typeof EDIT_MOCKUP_DATA;
 

--- a/app/(route)/post/_components/DetailInfo.tsx
+++ b/app/(route)/post/_components/DetailInfo.tsx
@@ -9,12 +9,8 @@ import DetailInput from "./_inputs/DetailInput";
 const DetailInfo = () => {
   const { getValues, setValue, control, watch } = useFormContext<PostType>();
   const [isCheck, setIsCheck] = useState(false);
-  const [imgList, setImgList] = useState<File[]>(getValues("images"));
+  const [imgList, setImgList] = useState<(File | string)[]>(getValues("images"));
   const { images } = watch();
-
-  const handleNextClick = () => {
-    setValue("images", imgList);
-  };
 
   return (
     <div className="flex flex-col gap-24">
@@ -30,7 +26,7 @@ const DetailInfo = () => {
         getValues={getValues}
         setValue={setValue}
       />
-      <PostFooter onNextStep={handleNextClick} isDisabled={!isCheck || getValues("detailText").length > 100} />
+      <PostFooter isDisabled={!isCheck || getValues("detailText").length > 100} />
     </div>
   );
 };

--- a/app/(route)/post/_components/DetailInfo.tsx
+++ b/app/(route)/post/_components/DetailInfo.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
 import { useStore } from "@/store/index";
@@ -9,15 +8,13 @@ import DetailInput from "./_inputs/DetailInput";
 
 const DetailInfo = () => {
   const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
-  const { getValues, setValue, control, watch } = useFormContext<PostType>();
-  const [imgList, setImgList] = useState<(File | string)[]>(getValues("images"));
-  const { images } = watch();
+  const { getValues } = useFormContext<PostType>();
 
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="full" />
       <FunnelTitle step="상세 설명" />
-      <DetailInput imgList={imgList} setImgList={setImgList} images={images} control={control} getValues={getValues} setValue={setValue} />
+      <DetailInput />
       <PostFooter isDisabled={!isCheck || getValues("detailText").length > 100} />
     </div>
   );

--- a/app/(route)/post/_components/DetailInfo.tsx
+++ b/app/(route)/post/_components/DetailInfo.tsx
@@ -1,14 +1,15 @@
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
+import { useStore } from "@/store/index";
 import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
 import DetailInput from "./_inputs/DetailInput";
 
 const DetailInfo = () => {
+  const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
   const { getValues, setValue, control, watch } = useFormContext<PostType>();
-  const [isCheck, setIsCheck] = useState(false);
   const [imgList, setImgList] = useState<(File | string)[]>(getValues("images"));
   const { images } = watch();
 
@@ -16,16 +17,7 @@ const DetailInfo = () => {
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="full" />
       <FunnelTitle step="상세 설명" />
-      <DetailInput
-        isCheck={isCheck}
-        setIsCheck={setIsCheck}
-        imgList={imgList}
-        setImgList={setImgList}
-        images={images}
-        control={control}
-        getValues={getValues}
-        setValue={setValue}
-      />
+      <DetailInput imgList={imgList} setImgList={setImgList} images={images} control={control} getValues={getValues} setValue={setValue} />
       <PostFooter isDisabled={!isCheck || getValues("detailText").length > 100} />
     </div>
   );

--- a/app/(route)/post/_components/DetailInfo.tsx
+++ b/app/(route)/post/_components/DetailInfo.tsx
@@ -1,12 +1,10 @@
-import classNames from "classnames";
-import Image from "next/image";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
-import InputFile from "@/components/input/InputFile";
 import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
+import DetailInput from "./_inputs/DetailInput";
 
 const DetailInfo = () => {
   const { getValues, setValue, control, watch } = useFormContext<PostType>();
@@ -18,71 +16,23 @@ const DetailInfo = () => {
     setValue("images", imgList);
   };
 
-  useEffect(() => {
-    const newList = imgList.length > 0 ? Array.from(images).filter((file) => !imgList?.includes(file)) : images;
-    setImgList((prev) => [...prev, ...newList]);
-  }, [images]);
-
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="full" />
       <FunnelTitle step="상세 설명" />
-      <main>
-        <ImageSection imgList={imgList} setImgList={setImgList} />
-        <label className="flex flex-col">
-          상세 내용
-          <Controller
-            control={control}
-            name="detailText"
-            rules={{ maxLength: 100 }}
-            render={({ field: { onChange, onBlur, value } }) => (
-              <textarea
-                id="detail_text"
-                className="h-120 rounded-sm bg-gray-100 px-16 py-12"
-                placeholder="이벤트를 설명하세요."
-                onChange={onChange}
-                onBlur={onBlur}
-                value={value}
-              />
-            )}
-          />
-          <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": getValues("detailText").length > 100 })}>{getValues("detailText").length} / 100</div>
-        </label>
-        <div className="rounded-sm bg-[#DDD] px-12 py-8">
-          허위 등록, 악의적인 등록은 삭제될 수 있으며, 이로 인한 피해가 발생할 경우 전적으로 게시자가 책임집니다.(대략이런내용) 이용약관 상수로 관리할까여말까여 흠 고민고민..
-        </div>
-        {isCheck ? <div onClick={() => setIsCheck(false)}>체크됨</div> : <div onClick={() => setIsCheck(true)}>클릭하면 체크</div>}
-      </main>
+      <DetailInput
+        isCheck={isCheck}
+        setIsCheck={setIsCheck}
+        imgList={imgList}
+        setImgList={setImgList}
+        images={images}
+        control={control}
+        getValues={getValues}
+        setValue={setValue}
+      />
       <PostFooter onNextStep={handleNextClick} isDisabled={!isCheck || getValues("detailText").length > 100} />
     </div>
   );
 };
 
 export default DetailInfo;
-
-interface ImageSectionProps {
-  imgList: File[];
-  setImgList: Dispatch<SetStateAction<File[]>>;
-}
-
-const ImageSection = ({ imgList, setImgList }: ImageSectionProps) => {
-  return (
-    <div className="flex flex-col gap-8">
-      <div>이미지</div>
-      <div className="flex gap-8">
-        <InputFile name="images" />
-        <div className="scrollbar-hide flex w-[400px] gap-8 overflow-x-scroll">
-          {Array.from(imgList).map((file, idx) => (
-            <div key={idx} className="relative flex h-120 w-120 shrink-0">
-              <div className="absolute right-0 top-0 z-popup cursor-pointer" onClick={() => setImgList((prev) => prev.filter((item: File) => item !== file))}>
-                삭제
-              </div>
-              <Image src={URL.createObjectURL(file)} alt="선택한 사진 미리보기" fill className="object-cover" />
-            </div>
-          ))}
-        </div>
-      </div>
-      <div className="text-12 text-[#A2A5AA]">첫번째 이미지 썸네일 등록</div>
-    </div>
-  );
-};

--- a/app/(route)/post/_components/FunnelTitle.tsx
+++ b/app/(route)/post/_components/FunnelTitle.tsx
@@ -7,10 +7,10 @@ const POST_FUNNEL_TITLE = {
 
 interface Props {
   step: "행사 대상" | "행사 정보" | "특전 정보" | "상세 설명";
+  isRequired?: boolean;
 }
 
-const FunnelTitle = ({ step }: Props) => {
-  const isRequired = step.includes("행사");
+const FunnelTitle = ({ step, isRequired = false }: Props) => {
   return (
     <div className="flex-col gap-8">
       <div className="text-20 font-900">{POST_FUNNEL_TITLE[step]}</div>

--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -3,8 +3,8 @@ import { Dispatch, SetStateAction } from "react";
 import InputFile from "@/components/input/InputFile";
 
 interface Props {
-  imgList: File[];
-  setImgList: Dispatch<SetStateAction<File[]>>;
+  imgList: (File | string)[];
+  setImgList: Dispatch<SetStateAction<(File | string)[]>>;
 }
 
 const ImageSection = ({ imgList, setImgList }: Props) => {
@@ -13,13 +13,13 @@ const ImageSection = ({ imgList, setImgList }: Props) => {
       <div>이미지</div>
       <div className="flex gap-8">
         <InputFile name="images" />
-        <div className="scrollbar-hide flex w-[400px] gap-8 overflow-x-scroll">
+        <div className="flex w-[400px] gap-8 overflow-x-scroll scrollbar-hide">
           {Array.from(imgList).map((file, idx) => (
             <div key={idx} className="relative flex h-120 w-120 shrink-0">
-              <div className="absolute right-0 top-0 z-popup cursor-pointer" onClick={() => setImgList((prev) => prev.filter((item: File) => item !== file))}>
+              <div className="absolute right-0 top-0 z-popup cursor-pointer" onClick={() => setImgList((prev) => prev.filter((item) => item !== file))}>
                 삭제
               </div>
-              <Image src={URL.createObjectURL(file)} alt="선택한 사진 미리보기" fill className="object-cover" />
+              <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 사진 미리보기" fill className="object-cover" />
             </div>
           ))}
         </div>

--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import { Dispatch, SetStateAction } from "react";
+import InputFile from "@/components/input/InputFile";
+
+interface Props {
+  imgList: File[];
+  setImgList: Dispatch<SetStateAction<File[]>>;
+}
+
+const ImageSection = ({ imgList, setImgList }: Props) => {
+  return (
+    <div className="flex flex-col gap-8">
+      <div>이미지</div>
+      <div className="flex gap-8">
+        <InputFile name="images" />
+        <div className="scrollbar-hide flex w-[400px] gap-8 overflow-x-scroll">
+          {Array.from(imgList).map((file, idx) => (
+            <div key={idx} className="relative flex h-120 w-120 shrink-0">
+              <div className="absolute right-0 top-0 z-popup cursor-pointer" onClick={() => setImgList((prev) => prev.filter((item: File) => item !== file))}>
+                삭제
+              </div>
+              <Image src={URL.createObjectURL(file)} alt="선택한 사진 미리보기" fill className="object-cover" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="text-12 text-[#A2A5AA]">첫번째 이미지 썸네일 등록</div>
+    </div>
+  );
+};
+
+export default ImageSection;

--- a/app/(route)/post/_components/MainInfo.tsx
+++ b/app/(route)/post/_components/MainInfo.tsx
@@ -14,7 +14,6 @@ interface Props {
 
 const MainInfo = ({ onNextStep }: Props) => {
   const {
-    setValue,
     watch,
     formState: { isValid },
   } = useFormContext<PostType>();
@@ -26,7 +25,7 @@ const MainInfo = ({ onNextStep }: Props) => {
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="1/2" />
       <FunnelTitle step="행사 정보" isRequired />
-      <MainInput setValue={setValue} />
+      <MainInput />
       <PostFooter onNextStep={onNextStep} isDisabled={isDisabled} />
     </div>
   );

--- a/app/(route)/post/_components/MainInfo.tsx
+++ b/app/(route)/post/_components/MainInfo.tsx
@@ -25,7 +25,7 @@ const MainInfo = ({ onNextStep }: Props) => {
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="1/2" />
-      <FunnelTitle step="행사 정보" />
+      <FunnelTitle step="행사 정보" isRequired />
       <MainInput setValue={setValue} />
       <PostFooter onNextStep={onNextStep} isDisabled={isDisabled} />
     </div>

--- a/app/(route)/post/_components/MainInfo.tsx
+++ b/app/(route)/post/_components/MainInfo.tsx
@@ -1,20 +1,15 @@
 "use client";
 
-import classNames from "classnames";
-import { useEffect, useState } from "react";
 import "react-day-picker/dist/style.css";
-import { useForm, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
-import InputText from "@/components/input/InputText";
-import AddressModal from "@/components/modal/AddressModal";
-import CalendarModal from "@/components/modal/CalendarModal";
-import { useModal } from "@/hooks/useModal";
 import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
+import MainInput from "./_inputs/MainInput";
 
 interface Props {
-  onNextStep: () => void;
+  onNextStep?: () => void;
 }
 
 const MainInfo = ({ onNextStep }: Props) => {
@@ -23,7 +18,6 @@ const MainInfo = ({ onNextStep }: Props) => {
     watch,
     formState: { isValid },
   } = useFormContext<PostType>();
-  const { modal, openModal, closeModal } = useModal();
 
   const { title, address, startDate, endDate } = watch();
   const isDisabled = !title || !address || !startDate || !endDate || !isValid;
@@ -32,22 +26,8 @@ const MainInfo = ({ onNextStep }: Props) => {
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="1/2" />
       <FunnelTitle step="행사 정보" />
-      <main>
-        <InputText name="title" placeholder="카페 이름" rules={{ required: "제목을 입력해주세요." }}>
-          제목
-        </InputText>
-        <InputText name="address" placeholder="도로명주소 검색" readOnly onClick={() => openModal("address")}>
-          주소
-        </InputText>
-        <InputText name="detailAddress" placeholder="상세주소 입력" />
-        <InputText name="startDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")}>
-          기간
-        </InputText>
-        <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} />
-      </main>
+      <MainInput setValue={setValue} />
       <PostFooter onNextStep={onNextStep} isDisabled={isDisabled} />
-      {modal === "address" && <AddressModal setValue={setValue} closeModal={closeModal} />}
-      {modal === "date" && <CalendarModal setValue={setValue} closeModal={closeModal} />}
     </div>
   );
 };

--- a/app/(route)/post/_components/StarInfo.tsx
+++ b/app/(route)/post/_components/StarInfo.tsx
@@ -1,6 +1,4 @@
-import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
-import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
 import StarInput from "./_inputs/StarInput";
@@ -10,13 +8,11 @@ interface Props {
 }
 
 const StarInfo = ({ onNextStep }: Props) => {
-  const { setValue, getValues } = useFormContext<PostType>();
-
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="1/4" />
       <FunnelTitle step="행사 대상" isRequired />
-      <StarInput setValue={setValue} getValues={getValues} />
+      <StarInput />
       <PostFooter onNextStep={onNextStep} />
     </div>
   );

--- a/app/(route)/post/_components/StarInfo.tsx
+++ b/app/(route)/post/_components/StarInfo.tsx
@@ -1,51 +1,24 @@
-import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import Dropdown from "@/components/Dropdown";
 import ProgressBar from "@/components/ProgressBar";
-import BottomSheetFrame from "@/components/bottom-sheet/BottomSheetFrame";
-import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
-import InputText from "@/components/input/InputText";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
-
-const EVENT_TYPE_LIST = ["생일카페", "상영회", "팬싸", "또뭐하ㅏ지", "모르겠다", "배고프다", "붕어빵", "피자붕어빵"];
+import StarInput from "./_inputs/StarInput";
 
 interface Props {
-  onNextStep: () => void;
+  onNextStep?: () => void;
 }
 
 const StarInfo = ({ onNextStep }: Props) => {
   const { setValue, getValues } = useFormContext<PostType>();
-  const [eventType, setEventType] = useState(getValues("eventType"));
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
-
-  useEffect(() => {
-    setValue("eventType", eventType);
-  }, [eventType]);
 
   return (
-    <>
-      <div className="flex flex-col gap-24">
-        <ProgressBar ratio="1/4" />
-        <FunnelTitle step="행사 대상" />
-        <main className="flex-item flex flex-col gap-20">
-          <label>
-            연예인
-            <InputText name="group" placeholder="그룹선택" readOnly onClick={() => openBottomSheet("starGroup")} />
-            <InputText name="member" placeholder="멤버선택" readOnly />
-          </label>
-          <div>
-            <div>행사 유형</div>
-            <Dropdown itemList={EVENT_TYPE_LIST} selected={eventType} setSelected={setEventType} />
-          </div>
-        </main>
-        <InputText name="eventType" hidden />
-        <PostFooter onNextStep={onNextStep} />
-      </div>
-      {bottomSheet === "starGroup" && <StarBottomSheet closeBottomSheet={closeBottomSheet} />}
-    </>
+    <div className="flex flex-col gap-24">
+      <ProgressBar ratio="1/4" />
+      <FunnelTitle step="행사 대상" />
+      <StarInput setValue={setValue} getValues={getValues} />
+      <PostFooter onNextStep={onNextStep} />
+    </div>
   );
 };
 

--- a/app/(route)/post/_components/StarInfo.tsx
+++ b/app/(route)/post/_components/StarInfo.tsx
@@ -15,7 +15,7 @@ const StarInfo = ({ onNextStep }: Props) => {
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="1/4" />
-      <FunnelTitle step="행사 대상" />
+      <FunnelTitle step="행사 대상" isRequired />
       <StarInput setValue={setValue} getValues={getValues} />
       <PostFooter onNextStep={onNextStep} />
     </div>

--- a/app/(route)/post/_components/SubInfo.tsx
+++ b/app/(route)/post/_components/SubInfo.tsx
@@ -1,71 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import GiftTag from "@/components/GiftTag";
 import ProgressBar from "@/components/ProgressBar";
-import InputText from "@/components/input/InputText";
 import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
-
-const SNS_TYPE_LIST = ["트위터", "인스타그램", "유튜브", "기타"];
-const GIFT_LIST = ["컵홀더", "포토카드", "엽서", "티켓", "포스터", "스티커", "굿즈", "기타"];
+import SubInput from "./_inputs/SubInput";
 
 interface Props {
-  onNextStep: () => void;
+  onNextStep?: () => void;
 }
 
 const SubInfo = ({ onNextStep }: Props) => {
   const { setValue, getValues } = useFormContext<PostType>();
-  const [snsType, setSnsType] = useState(getValues("snsType"));
-  const [giftList, setGiftList] = useState<string[]>(getValues("gift"));
-
-  const handleRadioChange = (event: any) => {
-    setSnsType(event.target.value);
-  };
-
-  const handleGiftClick = (gift: any) => {
-    if (giftList.includes(gift)) return setGiftList((prev) => prev.filter((item) => item !== gift));
-    setGiftList((prev) => [...prev, gift]);
-  };
-
-  useEffect(() => {
-    setValue("gift", giftList);
-  }, [giftList]);
-
-  useEffect(() => {
-    setValue("snsType", snsType);
-  }, [snsType]);
 
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="3/4" />
       <FunnelTitle step="특전 정보" />
-      <main>
-        <InputText name="snsId" placeholder="SNS 아이디 입력">
-          주최자
-        </InputText>
-        {SNS_TYPE_LIST.map((type) => (
-          <label key={type}>
-            <input name="sns" value={type} type="radio" onChange={handleRadioChange} checked={snsType === type} />
-            {type}
-          </label>
-        ))}
-        <InputText name="eventUrl" placeholder="URL 입력">
-          행사 링크
-        </InputText>
-        <label>
-          특전
-          {GIFT_LIST.map((gift) => (
-            <GiftTag key={gift} handleClick={handleGiftClick} initialChecked={giftList.includes(gift)}>
-              {gift}
-            </GiftTag>
-          ))}
-        </label>
-      </main>
-      <InputText name="gift" hidden />
-      <InputText name="snsType" hidden />
+      <SubInput setValue={setValue} getValues={getValues} />
       <PostFooter onNextStep={onNextStep} />
     </div>
   );

--- a/app/(route)/post/_components/SubInfo.tsx
+++ b/app/(route)/post/_components/SubInfo.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useFormContext } from "react-hook-form";
 import ProgressBar from "@/components/ProgressBar";
-import { PostType } from "../page";
 import FunnelTitle from "./FunnelTitle";
 import PostFooter from "./PostFooter";
 import SubInput from "./_inputs/SubInput";
@@ -12,13 +10,11 @@ interface Props {
 }
 
 const SubInfo = ({ onNextStep }: Props) => {
-  const { setValue, getValues } = useFormContext<PostType>();
-
   return (
     <div className="flex flex-col gap-24">
       <ProgressBar ratio="3/4" />
       <FunnelTitle step="특전 정보" />
-      <SubInput setValue={setValue} getValues={getValues} />
+      <SubInput />
       <PostFooter onNextStep={onNextStep} />
     </div>
   );

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -8,26 +8,28 @@ interface Props {
   control: Control<PostType, any>;
   isCheck: boolean;
   setIsCheck: Dispatch<SetStateAction<boolean>>;
-  imgList: File[];
-  setImgList: Dispatch<SetStateAction<File[]>>;
-  images: File[];
+  imgList: (File | string)[];
+  setImgList: Dispatch<SetStateAction<(File | string)[]>>;
+  images: (File | string)[];
   getValues: UseFormGetValues<PostType>;
   setValue: UseFormSetValue<PostType>;
 }
 
 const DetailInput = ({ control, isCheck, setIsCheck, imgList, setImgList, images, getValues, setValue }: Props) => {
   useEffect(() => {
-    const newList = imgList.length > 0 ? Array.from(images).filter((file) => !Array.from(imgList).includes(file)) : images;
+    if (Array.from(images).filter((image) => !imgList.includes(image)).length === 0) {
+      return;
+    }
+    const newList = imgList.length > 0 ? Array.from(images).filter((file) => !imgList?.includes(file)) : images;
     setImgList((prev) => [...prev, ...newList]);
   }, [images]);
 
-  // useEffect(() => {
-  // 완벽하게 두 값을 동기화하려면 이 로직이 필요한데....... 무한루프탑승이고,, ㅎr.......
-  //   setValue('images', imgList);
-  // }, [imgList]);
+  useEffect(() => {
+    setValue("images", imgList);
+  }, [imgList]);
 
   return (
-    <main>
+    <>
       <ImageSection imgList={imgList} setImgList={setImgList} />
       <label className="flex flex-col">
         상세 내용
@@ -45,7 +47,7 @@ const DetailInput = ({ control, isCheck, setIsCheck, imgList, setImgList, images
         허위 등록, 악의적인 등록은 삭제될 수 있으며, 이로 인한 피해가 발생할 경우 전적으로 게시자가 책임집니다.(대략이런내용) 이용약관 상수로 관리할까여말까여 흠 고민고민..
       </div>
       {isCheck ? <div onClick={() => setIsCheck(false)}>체크됨</div> : <div onClick={() => setIsCheck(true)}>클릭하면 체크</div>}
-    </main>
+    </>
   );
 };
 

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -1,13 +1,12 @@
 import classNames from "classnames";
 import { Dispatch, SetStateAction, useEffect } from "react";
 import { Control, Controller, UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import WarningCheck from "@/components/WarningCheck";
 import { PostType } from "../../page";
 import ImageSection from "../ImageSection";
 
 interface Props {
   control: Control<PostType, any>;
-  isCheck: boolean;
-  setIsCheck: Dispatch<SetStateAction<boolean>>;
   imgList: (File | string)[];
   setImgList: Dispatch<SetStateAction<(File | string)[]>>;
   images: (File | string)[];
@@ -15,7 +14,7 @@ interface Props {
   setValue: UseFormSetValue<PostType>;
 }
 
-const DetailInput = ({ control, isCheck, setIsCheck, imgList, setImgList, images, getValues, setValue }: Props) => {
+const DetailInput = ({ control, imgList, setImgList, images, getValues, setValue }: Props) => {
   useEffect(() => {
     if (Array.from(images).filter((image) => !imgList.includes(image)).length === 0) {
       return;
@@ -43,10 +42,7 @@ const DetailInput = ({ control, isCheck, setIsCheck, imgList, setImgList, images
         />
         <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": getValues("detailText").length > 100 })}>{getValues("detailText").length} / 100</div>
       </label>
-      <div className="rounded-sm bg-[#DDD] px-12 py-8">
-        허위 등록, 악의적인 등록은 삭제될 수 있으며, 이로 인한 피해가 발생할 경우 전적으로 게시자가 책임집니다.(대략이런내용) 이용약관 상수로 관리할까여말까여 흠 고민고민..
-      </div>
-      {isCheck ? <div onClick={() => setIsCheck(false)}>체크됨</div> : <div onClick={() => setIsCheck(true)}>클릭하면 체크</div>}
+      <WarningCheck />
     </>
   );
 };

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -1,20 +1,21 @@
-import classNames from "classnames";
-import { Dispatch, SetStateAction, useEffect } from "react";
-import { Control, Controller, UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import { useEffect, useState } from "react";
+import { useFormContext } from "react-hook-form";
 import WarningCheck from "@/components/WarningCheck";
+import InputArea from "@/components/input/InputArea";
+import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
 import ImageSection from "../ImageSection";
 
-interface Props {
-  control: Control<PostType, any>;
-  imgList: (File | string)[];
-  setImgList: Dispatch<SetStateAction<(File | string)[]>>;
-  images: (File | string)[];
-  getValues: UseFormGetValues<PostType>;
-  setValue: UseFormSetValue<PostType>;
-}
+const DetailInput = () => {
+  const {
+    formState: { defaultValues },
+    getValues,
+    setValue,
+    watch,
+  } = useFormContext<PostType>();
+  const [imgList, setImgList] = useState<(File | string)[]>(getValues("images"));
+  const { images } = watch();
 
-const DetailInput = ({ control, imgList, setImgList, images, getValues, setValue }: Props) => {
   useEffect(() => {
     if (Array.from(images).filter((image) => !imgList.includes(image)).length === 0) {
       return;
@@ -30,18 +31,9 @@ const DetailInput = ({ control, imgList, setImgList, images, getValues, setValue
   return (
     <>
       <ImageSection imgList={imgList} setImgList={setImgList} />
-      <label className="flex flex-col">
+      <InputArea name="detailText" placeholder="이벤트 설명을 입력하세요." rules={{ maxLength: 100 }} isEdit={validateEdit(defaultValues?.detailText !== getValues("detailText"))}>
         상세 내용
-        <Controller
-          control={control}
-          name="detailText"
-          rules={{ maxLength: 100 }}
-          render={({ field: { onChange, onBlur, value } }) => (
-            <textarea id="detail_text" className="h-120 rounded-sm bg-gray-100 px-16 py-12" placeholder="이벤트를 설명하세요." onChange={onChange} onBlur={onBlur} value={value} />
-          )}
-        />
-        <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": getValues("detailText").length > 100 })}>{getValues("detailText").length} / 100</div>
-      </label>
+      </InputArea>
       <WarningCheck />
     </>
   );

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -1,0 +1,52 @@
+import classNames from "classnames";
+import { Dispatch, SetStateAction, useEffect } from "react";
+import { Control, Controller, UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import { PostType } from "../../page";
+import ImageSection from "../ImageSection";
+
+interface Props {
+  control: Control<PostType, any>;
+  isCheck: boolean;
+  setIsCheck: Dispatch<SetStateAction<boolean>>;
+  imgList: File[];
+  setImgList: Dispatch<SetStateAction<File[]>>;
+  images: File[];
+  getValues: UseFormGetValues<PostType>;
+  setValue: UseFormSetValue<PostType>;
+}
+
+const DetailInput = ({ control, isCheck, setIsCheck, imgList, setImgList, images, getValues, setValue }: Props) => {
+  useEffect(() => {
+    const newList = imgList.length > 0 ? Array.from(images).filter((file) => !Array.from(imgList).includes(file)) : images;
+    setImgList((prev) => [...prev, ...newList]);
+  }, [images]);
+
+  // useEffect(() => {
+  // 완벽하게 두 값을 동기화하려면 이 로직이 필요한데....... 무한루프탑승이고,, ㅎr.......
+  //   setValue('images', imgList);
+  // }, [imgList]);
+
+  return (
+    <main>
+      <ImageSection imgList={imgList} setImgList={setImgList} />
+      <label className="flex flex-col">
+        상세 내용
+        <Controller
+          control={control}
+          name="detailText"
+          rules={{ maxLength: 100 }}
+          render={({ field: { onChange, onBlur, value } }) => (
+            <textarea id="detail_text" className="h-120 rounded-sm bg-gray-100 px-16 py-12" placeholder="이벤트를 설명하세요." onChange={onChange} onBlur={onBlur} value={value} />
+          )}
+        />
+        <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": getValues("detailText").length > 100 })}>{getValues("detailText").length} / 100</div>
+      </label>
+      <div className="rounded-sm bg-[#DDD] px-12 py-8">
+        허위 등록, 악의적인 등록은 삭제될 수 있으며, 이로 인한 피해가 발생할 경우 전적으로 게시자가 책임집니다.(대략이런내용) 이용약관 상수로 관리할까여말까여 흠 고민고민..
+      </div>
+      {isCheck ? <div onClick={() => setIsCheck(false)}>체크됨</div> : <div onClick={() => setIsCheck(true)}>클릭하면 체크</div>}
+    </main>
+  );
+};
+
+export default DetailInput;

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -1,22 +1,17 @@
-import { usePathname } from "next/navigation";
-import { UseFormSetValue, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import InputText from "@/components/input/InputText";
 import AddressModal from "@/components/modal/AddressModal";
 import CalendarModal from "@/components/modal/CalendarModal";
 import { useModal } from "@/hooks/useModal";
-import { useStore } from "@/store/index";
 import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
 
-interface Props {
-  setValue: UseFormSetValue<PostType>;
-}
-
-const MainInput = ({ setValue }: Props) => {
+const MainInput = () => {
   const { modal, openModal, closeModal } = useModal();
   const {
     formState: { defaultValues },
     watch,
+    setValue,
   } = useFormContext<PostType>();
   const { title, address, detailAddress, startDate, endDate } = watch();
 

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -1,0 +1,39 @@
+import { UseFormSetValue, useFormContext } from "react-hook-form";
+import InputText from "@/components/input/InputText";
+import AddressModal from "@/components/modal/AddressModal";
+import CalendarModal from "@/components/modal/CalendarModal";
+import { useModal } from "@/hooks/useModal";
+import { PostType } from "../../page";
+
+interface Props {
+  setValue: UseFormSetValue<PostType>;
+}
+
+const MainInput = ({ setValue }: Props) => {
+  const { modal, openModal, closeModal } = useModal();
+  const {
+    formState: { defaultValues },
+    watch,
+  } = useFormContext<PostType>();
+  const { title, address, detailAddress, startDate, endDate } = watch();
+
+  return (
+    <main>
+      <InputText name="title" placeholder="카페 이름" rules={{ required: "제목을 입력해주세요." }} isEdit={defaultValues?.title !== title}>
+        제목
+      </InputText>
+      <InputText name="address" placeholder="도로명주소 검색" readOnly onClick={() => openModal("address")} isEdit={defaultValues?.address !== address}>
+        주소
+      </InputText>
+      <InputText name="detailAddress" placeholder="상세주소 입력" isEdit={defaultValues?.detailAddress !== detailAddress} />
+      <InputText name="startDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={defaultValues?.startDate !== startDate}>
+        기간
+      </InputText>
+      <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={defaultValues?.endDate !== endDate} />
+      {modal === "address" && <AddressModal setValue={setValue} closeModal={closeModal} />}
+      {modal === "date" && <CalendarModal setValue={setValue} closeModal={closeModal} />}
+    </main>
+  );
+};
+
+export default MainInput;

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -1,8 +1,11 @@
+import { usePathname } from "next/navigation";
 import { UseFormSetValue, useFormContext } from "react-hook-form";
 import InputText from "@/components/input/InputText";
 import AddressModal from "@/components/modal/AddressModal";
 import CalendarModal from "@/components/modal/CalendarModal";
 import { useModal } from "@/hooks/useModal";
+import { useStore } from "@/store/index";
+import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
 
 interface Props {
@@ -19,17 +22,17 @@ const MainInput = ({ setValue }: Props) => {
 
   return (
     <>
-      <InputText name="title" placeholder="카페 이름" rules={{ required: "제목을 입력해주세요." }} isEdit={defaultValues?.title !== title}>
+      <InputText name="title" placeholder="카페 이름" rules={{ required: "제목을 입력해주세요." }} isEdit={validateEdit(defaultValues?.title !== title)}>
         제목
       </InputText>
-      <InputText name="address" placeholder="도로명주소 검색" readOnly onClick={() => openModal("address")} isEdit={defaultValues?.address !== address}>
+      <InputText name="address" placeholder="도로명주소 검색" readOnly onClick={() => openModal("address")} isEdit={validateEdit(defaultValues?.address !== address)}>
         주소
       </InputText>
       <InputText name="detailAddress" placeholder="상세주소 입력" isEdit={defaultValues?.detailAddress !== detailAddress} />
-      <InputText name="startDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={defaultValues?.startDate !== startDate}>
+      <InputText name="startDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={validateEdit(defaultValues?.startDate !== startDate)}>
         기간
       </InputText>
-      <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={defaultValues?.endDate !== endDate} />
+      <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={validateEdit(defaultValues?.endDate !== endDate)} />
       {modal === "address" && <AddressModal setValue={setValue} closeModal={closeModal} />}
       {modal === "date" && <CalendarModal setValue={setValue} closeModal={closeModal} />}
     </>

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -18,7 +18,7 @@ const MainInput = ({ setValue }: Props) => {
   const { title, address, detailAddress, startDate, endDate } = watch();
 
   return (
-    <main>
+    <>
       <InputText name="title" placeholder="카페 이름" rules={{ required: "제목을 입력해주세요." }} isEdit={defaultValues?.title !== title}>
         제목
       </InputText>
@@ -32,7 +32,7 @@ const MainInput = ({ setValue }: Props) => {
       <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openModal("date")} isEdit={defaultValues?.endDate !== endDate} />
       {modal === "address" && <AddressModal setValue={setValue} closeModal={closeModal} />}
       {modal === "date" && <CalendarModal setValue={setValue} closeModal={closeModal} />}
-    </main>
+    </>
   );
 };
 

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -1,0 +1,44 @@
+import { EditPostType } from "@/(route)/event/[id]/edit/page";
+import { useEffect, useState } from "react";
+import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import Dropdown from "@/components/Dropdown";
+import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
+import InputText from "@/components/input/InputText";
+import { useBottomSheet } from "@/hooks/useBottomSheet";
+import { PostType } from "../../page";
+
+const EVENT_TYPE_LIST = ["생일카페", "상영회", "팬싸", "또뭐하ㅏ지", "모르겠다", "배고프다", "붕어빵", "피자붕어빵"];
+
+interface Props {
+  getValues: UseFormGetValues<PostType>;
+  setValue: UseFormSetValue<PostType>;
+}
+
+const StarInput = ({ getValues, setValue }: Props) => {
+  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const [eventType, setEventType] = useState(getValues("eventType"));
+
+  useEffect(() => {
+    setValue("eventType", eventType);
+  }, [eventType]);
+
+  return (
+    <>
+      <main className="flex-item flex flex-col gap-20">
+        <label>
+          연예인
+          <InputText name="group" placeholder="그룹선택" readOnly onClick={() => openBottomSheet("starGroup")} />
+          <InputText name="member" placeholder="멤버선택" readOnly />
+        </label>
+        <div>
+          <div>행사 유형</div>
+          <Dropdown itemList={EVENT_TYPE_LIST} selected={eventType} setSelected={setEventType} />
+        </div>
+      </main>
+      <InputText name="eventType" hidden />
+      {bottomSheet === "starGroup" && <StarBottomSheet closeBottomSheet={closeBottomSheet} />}
+    </>
+  );
+};
+
+export default StarInput;

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -24,7 +24,7 @@ const StarInput = ({ getValues, setValue }: Props) => {
 
   return (
     <>
-      <main className="flex-item flex flex-col gap-20">
+      <div className="flex-item flex flex-col gap-20">
         <label>
           연예인
           <InputText name="group" placeholder="그룹선택" readOnly onClick={() => openBottomSheet("starGroup")} />
@@ -34,7 +34,7 @@ const StarInput = ({ getValues, setValue }: Props) => {
           <div>행사 유형</div>
           <Dropdown itemList={EVENT_TYPE_LIST} selected={eventType} setSelected={setEventType} />
         </div>
-      </main>
+      </div>
       <InputText name="eventType" hidden />
       {bottomSheet === "starGroup" && <StarBottomSheet closeBottomSheet={closeBottomSheet} />}
     </>

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -1,21 +1,15 @@
-import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { useEffect, useState } from "react";
-import { UseFormGetValues, UseFormSetValue, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import Dropdown from "@/components/Dropdown";
 import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
 import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
-import { useStore } from "@/store/index";
 import { PostType } from "../../page";
 
 const EVENT_TYPE_LIST = ["생일카페", "상영회", "팬싸", "또뭐하ㅏ지", "모르겠다", "배고프다", "붕어빵", "피자붕어빵"];
 
-interface Props {
-  getValues: UseFormGetValues<PostType>;
-  setValue: UseFormSetValue<PostType>;
-}
-
-const StarInput = ({ getValues, setValue }: Props) => {
+const StarInput = () => {
+  const { getValues, setValue } = useFormContext<PostType>();
   const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
   const [eventType, setEventType] = useState(getValues("eventType"));
 

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -1,10 +1,11 @@
 import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { useEffect, useState } from "react";
-import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import { UseFormGetValues, UseFormSetValue, useFormContext } from "react-hook-form";
 import Dropdown from "@/components/Dropdown";
 import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
 import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
+import { useStore } from "@/store/index";
 import { PostType } from "../../page";
 
 const EVENT_TYPE_LIST = ["생일카페", "상영회", "팬싸", "또뭐하ㅏ지", "모르겠다", "배고프다", "붕어빵", "피자붕어빵"];
@@ -25,11 +26,11 @@ const StarInput = ({ getValues, setValue }: Props) => {
   return (
     <>
       <div className="flex-item flex flex-col gap-20">
-        <label>
+        <div>
           연예인
           <InputText name="group" placeholder="그룹선택" readOnly onClick={() => openBottomSheet("starGroup")} />
           <InputText name="member" placeholder="멤버선택" readOnly />
-        </label>
+        </div>
         <div>
           <div>행사 유형</div>
           <Dropdown itemList={EVENT_TYPE_LIST} selected={eventType} setSelected={setEventType} />

--- a/app/(route)/post/_components/_inputs/SubInput.tsx
+++ b/app/(route)/post/_components/_inputs/SubInput.tsx
@@ -1,6 +1,6 @@
 import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { useEffect, useState } from "react";
-import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import { UseFormGetValues, UseFormSetValue, useFormContext } from "react-hook-form";
 import GiftTag from "@/components/GiftTag";
 import InputText from "@/components/input/InputText";
 import { PostType } from "../../page";
@@ -14,8 +14,13 @@ interface Props {
 }
 
 const SubInput = ({ getValues, setValue }: Props) => {
+  const {
+    formState: { defaultValues },
+    watch,
+  } = useFormContext<PostType>();
   const [snsType, setSnsType] = useState(getValues("snsType"));
   const [giftList, setGiftList] = useState<string[]>(getValues("gift"));
+  const { snsId, eventUrl } = watch();
 
   const handleRadioChange = (event: any) => {
     setSnsType(event.target.value);
@@ -36,8 +41,8 @@ const SubInput = ({ getValues, setValue }: Props) => {
 
   return (
     <>
-      <main>
-        <InputText name="snsId" placeholder="SNS 아이디 입력">
+      <div>
+        <InputText name="snsId" placeholder="SNS 아이디 입력" isEdit={defaultValues?.snsId !== snsId}>
           주최자
         </InputText>
         {SNS_TYPE_LIST.map((type) => (
@@ -46,7 +51,7 @@ const SubInput = ({ getValues, setValue }: Props) => {
             {type}
           </label>
         ))}
-        <InputText name="eventUrl" placeholder="URL 입력">
+        <InputText name="eventUrl" placeholder="URL 입력" isEdit={defaultValues?.eventUrl !== eventUrl}>
           행사 링크
         </InputText>
         <label>
@@ -57,7 +62,7 @@ const SubInput = ({ getValues, setValue }: Props) => {
             </GiftTag>
           ))}
         </label>
-      </main>
+      </div>
       <InputText name="gift" hidden />
       <InputText name="snsType" hidden />
     </>

--- a/app/(route)/post/_components/_inputs/SubInput.tsx
+++ b/app/(route)/post/_components/_inputs/SubInput.tsx
@@ -1,0 +1,67 @@
+import { EditPostType } from "@/(route)/event/[id]/edit/page";
+import { useEffect, useState } from "react";
+import { UseFormGetValues, UseFormSetValue } from "react-hook-form";
+import GiftTag from "@/components/GiftTag";
+import InputText from "@/components/input/InputText";
+import { PostType } from "../../page";
+
+const SNS_TYPE_LIST = ["트위터", "인스타그램", "유튜브", "기타"];
+const GIFT_LIST = ["컵홀더", "포토카드", "엽서", "티켓", "포스터", "스티커", "굿즈", "기타"];
+
+interface Props {
+  getValues: UseFormGetValues<PostType>;
+  setValue: UseFormSetValue<PostType>;
+}
+
+const SubInput = ({ getValues, setValue }: Props) => {
+  const [snsType, setSnsType] = useState(getValues("snsType"));
+  const [giftList, setGiftList] = useState<string[]>(getValues("gift"));
+
+  const handleRadioChange = (event: any) => {
+    setSnsType(event.target.value);
+  };
+
+  const handleGiftClick = (gift: any) => {
+    if (giftList.includes(gift)) return setGiftList((prev) => prev.filter((item) => item !== gift));
+    setGiftList((prev) => [...prev, gift]);
+  };
+
+  useEffect(() => {
+    setValue("gift", giftList);
+  }, [giftList]);
+
+  useEffect(() => {
+    setValue("snsType", snsType);
+  }, [snsType]);
+
+  return (
+    <>
+      <main>
+        <InputText name="snsId" placeholder="SNS 아이디 입력">
+          주최자
+        </InputText>
+        {SNS_TYPE_LIST.map((type) => (
+          <label key={type}>
+            <input name="sns" value={type} type="radio" onChange={handleRadioChange} checked={snsType === type} />
+            {type}
+          </label>
+        ))}
+        <InputText name="eventUrl" placeholder="URL 입력">
+          행사 링크
+        </InputText>
+        <label>
+          특전
+          {GIFT_LIST.map((gift) => (
+            <GiftTag key={gift} handleClick={handleGiftClick} initialChecked={giftList.includes(gift)}>
+              {gift}
+            </GiftTag>
+          ))}
+        </label>
+      </main>
+      <InputText name="gift" hidden />
+      <InputText name="snsType" hidden />
+    </>
+  );
+};
+
+export default SubInput;

--- a/app/(route)/post/_components/_inputs/SubInput.tsx
+++ b/app/(route)/post/_components/_inputs/SubInput.tsx
@@ -1,6 +1,5 @@
-import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { useEffect, useState } from "react";
-import { UseFormGetValues, UseFormSetValue, useFormContext } from "react-hook-form";
+import { useFormContext } from "react-hook-form";
 import GiftTag from "@/components/GiftTag";
 import InputText from "@/components/input/InputText";
 import { PostType } from "../../page";
@@ -8,15 +7,12 @@ import { PostType } from "../../page";
 const SNS_TYPE_LIST = ["트위터", "인스타그램", "유튜브", "기타"];
 const GIFT_LIST = ["컵홀더", "포토카드", "엽서", "티켓", "포스터", "스티커", "굿즈", "기타"];
 
-interface Props {
-  getValues: UseFormGetValues<PostType>;
-  setValue: UseFormSetValue<PostType>;
-}
-
-const SubInput = ({ getValues, setValue }: Props) => {
+const SubInput = () => {
   const {
     formState: { defaultValues },
     watch,
+    getValues,
+    setValue,
   } = useFormContext<PostType>();
   const [snsType, setSnsType] = useState(getValues("snsType"));
   const [giftList, setGiftList] = useState<string[]>(getValues("gift"));

--- a/app/(route)/post/page.tsx
+++ b/app/(route)/post/page.tsx
@@ -29,7 +29,7 @@ const DEFAULT_INPUT_VALUES = {
 
 const POST_STEPS: SignupStepNameType[] = ["계정 정보", "프로필 정보", "아티스트 선택"];
 
-export type PostType = Omit<typeof DEFAULT_INPUT_VALUES, "gift" | "images" | "member"> & { gift: string[]; images: File[]; member: string[] };
+export type PostType = Omit<typeof DEFAULT_INPUT_VALUES, "gift" | "images" | "member"> & { gift: string[]; images: File[] | string[]; member: string[] };
 
 const Post = () => {
   const { Funnel, Step, setStep, currentStep } = useFunnel(POST_STEPS);

--- a/app/(route)/post/page.tsx
+++ b/app/(route)/post/page.tsx
@@ -29,7 +29,7 @@ const DEFAULT_INPUT_VALUES = {
 
 const POST_STEPS: SignupStepNameType[] = ["계정 정보", "프로필 정보", "아티스트 선택"];
 
-export type PostType = Omit<typeof DEFAULT_INPUT_VALUES, "gift" | "images" | "member"> & { gift: string[]; images: File[] | string[]; member: string[] };
+export type PostType = Omit<typeof DEFAULT_INPUT_VALUES, "gift" | "images" | "member"> & { gift: string[]; images: (File | string)[]; member: string[] };
 
 const Post = () => {
   const { Funnel, Step, setStep, currentStep } = useFunnel(POST_STEPS);

--- a/app/_components/Dropdown.tsx
+++ b/app/_components/Dropdown.tsx
@@ -23,7 +23,7 @@ const Dropdown = ({ itemList, selected, setSelected }: Props) => {
           </span>
         </Listbox.Button>
         <Transition as={Fragment} leave="transition ease-in duration-100" leaveFrom="opacity-100" leaveTo="opacity-0">
-          <Listbox.Options className="mt-1 py-1 text-base sm:text-sm absolute max-h-[170px] w-full overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none">
+          <Listbox.Options className="mt-1 py-1 text-base sm:text-sm absolute z-popup max-h-[170px] w-full overflow-auto rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none">
             {itemList.map((item, idx) => (
               <Listbox.Option
                 key={idx}

--- a/app/_components/WarningCheck.tsx
+++ b/app/_components/WarningCheck.tsx
@@ -1,0 +1,15 @@
+import { useStore } from "../_store";
+
+const WarningCheck = () => {
+  const { isCheck, setIsCheck } = useStore((state) => ({ isCheck: state.isWarningCheck, setIsCheck: state.setIsWarningCheck }));
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="rounded-sm bg-[#DDD] px-12 py-8">
+        허위 등록, 악의적인 등록은 삭제될 수 있으며, 이로 인한 피해가 발생할 경우 전적으로 게시자가 책임집니다.(대략이런내용) 이용약관 상수로 관리할까여말까여 흠 고민고민..
+      </div>
+      {isCheck ? <div onClick={() => setIsCheck(false)}>체크됨</div> : <div onClick={() => setIsCheck(true)}>클릭하면 체크</div>}
+    </div>
+  );
+};
+
+export default WarningCheck;

--- a/app/_components/input/InputArea.tsx
+++ b/app/_components/input/InputArea.tsx
@@ -27,7 +27,7 @@ const InputArea: Function = ({ children, placeholder, onKeyDown, isEdit, ...cont
         placeholder={placeholder ?? "입력해주세요."}
         {...field}
         onKeyDown={onKeyDown}
-        className={classNames("h-120 rounded-sm bg-gray-100 px-16 py-12", { "border-2 border-blue-700": isEdit })}
+        className={classNames("h-120 rounded-sm bg-gray-100 px-16 py-12", { "border border-blue-500 outline-none": isEdit })}
       />
       <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": field.value.length > 100 })}>{field.value.length} / 100</div>
     </div>

--- a/app/_components/input/InputArea.tsx
+++ b/app/_components/input/InputArea.tsx
@@ -1,0 +1,37 @@
+import classNames from "classnames";
+import Image from "next/image";
+import { KeyboardEvent, ReactNode, useState } from "react";
+import { FieldPath, FieldValues, UseControllerProps, useController } from "react-hook-form";
+
+interface Prop {
+  children?: ReactNode;
+  placeholder?: string;
+  onKeyDown?: (e: KeyboardEvent) => void;
+  isEdit?: boolean;
+}
+
+type Function = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(
+  prop: UseControllerProps<TFieldValues, TName> & Prop,
+) => ReactNode;
+
+const InputArea: Function = ({ children, placeholder, onKeyDown, isEdit, ...control }) => {
+  const { field } = useController(control);
+
+  return (
+    <div className="flex flex-col ">
+      <label htmlFor={field.name} className="text-14">
+        {children}
+      </label>
+      <textarea
+        id={field.name}
+        placeholder={placeholder ?? "입력해주세요."}
+        {...field}
+        onKeyDown={onKeyDown}
+        className={classNames("h-120 rounded-sm bg-gray-100 px-16 py-12", { "border-2 border-blue-700": isEdit })}
+      />
+      <div className={classNames("text-12 text-[#A2A5AA]", { "text-red-600": field.value.length > 100 })}>{field.value.length} / 100</div>
+    </div>
+  );
+};
+
+export default InputArea;

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -53,7 +53,7 @@ const InputText: Function = ({ type: initialType, children, placeholder, autoCom
           className={classNames(
             "border-solid-gray body1-normal placeholder:text-gray-4 focus:border-purple mt-10 h-48 w-full rounded-md bg-blue-50 p-16 text-14 text-black outline-none",
             { hidden: hidden ?? false },
-            { "outline-1 outline-blue-700": isEdit },
+            { "border border-blue-500 outline-none": isEdit },
           )}
         />
         {initialType === "password" && (

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -15,13 +15,14 @@ interface Prop {
   disabled?: boolean;
   onKeyDown?: (e: KeyboardEvent) => void;
   onClick?: () => void;
+  isEdit?: boolean;
 }
 
 type Function = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(
   prop: UseControllerProps<TFieldValues, TName> & Prop,
 ) => ReactNode;
 
-const InputText: Function = ({ type: initialType, children, placeholder, autoComplete, hint, maxLength, hidden, readOnly, disabled, onClick, onKeyDown, ...control }) => {
+const InputText: Function = ({ type: initialType, children, placeholder, autoComplete, hint, maxLength, hidden, readOnly, disabled, onClick, onKeyDown, isEdit, ...control }) => {
   const { field, fieldState } = useController(control);
   const [type, setType] = useState(initialType ?? "text");
 
@@ -51,6 +52,7 @@ const InputText: Function = ({ type: initialType, children, placeholder, autoCom
         className={classNames(
           "border-solid-gray body1-normal placeholder:text-gray-4 focus:border-purple mt-10 h-48 w-full rounded-md bg-blue-50 p-16 text-14 text-black outline-none",
           { hidden: hidden ?? false },
+          { "outline-1 outline-blue-700": isEdit },
         )}
       />
       {initialType === "password" && (

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -35,44 +35,48 @@ const InputText: Function = ({ type: initialType, children, placeholder, autoCom
   };
 
   return (
-    <div className="relative">
+    <div>
       <label htmlFor={field.name} className="text-14">
         {children}
       </label>
-      <input
-        id={field.name}
-        type={type}
-        placeholder={placeholder ?? "입력해주세요."}
-        autoComplete={autoComplete ?? "off"}
-        readOnly={readOnly ?? false}
-        disabled={disabled ?? false}
-        onClick={onClick}
-        {...field}
-        onKeyDown={onKeyDown}
-        className={classNames(
-          "border-solid-gray body1-normal placeholder:text-gray-4 focus:border-purple mt-10 h-48 w-full rounded-md bg-blue-50 p-16 text-14 text-black outline-none",
-          { hidden: hidden ?? false },
-          { "outline-1 outline-blue-700": isEdit },
-        )}
-      />
-      {initialType === "password" && (
-        <button
-          onClick={handlePasswordShow}
+      <div className="relative">
+        <input
+          id={field.name}
+          type={type}
+          placeholder={placeholder ?? "입력해주세요."}
+          autoComplete={autoComplete ?? "off"}
+          readOnly={readOnly ?? false}
+          disabled={disabled ?? false}
+          onClick={onClick}
+          {...field}
           onKeyDown={onKeyDown}
-          type="button"
-          className="absolute right-0 top-44 flex h-24 w-24 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
-        >
-          {<Image src={type === "password" ? "/icon/closed-eyes_black.svg" : "/icon/opened-eyes_black.svg"} alt="비밀번호 아이콘" width={16} height={16} />}
-        </button>
-      )}
-      {initialType !== "password" && !hidden && (
-        <button onClick={handleDelete} onKeyDown={onKeyDown} type="button" className="absolute right-0 top-44 h-24 w-24 -translate-x-1/2 -translate-y-1/2">
-          <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
-        </button>
-      )}
-      <div className="flex gap-8">
-        {maxLength ? <span className={classNames("mt-4 h-8", { "text-red-500": field.value.length > maxLength })}>{`(${field.value.length}/${maxLength})`}</span> : null}
-        <p className={classNames(`font-normal mt-4 h-8 text-12`, { "text-red-500": fieldState.error, "text-gray-400": !fieldState.error })}>{fieldState?.error?.message || hint}</p>
+          className={classNames(
+            "border-solid-gray body1-normal placeholder:text-gray-4 focus:border-purple mt-10 h-48 w-full rounded-md bg-blue-50 p-16 text-14 text-black outline-none",
+            { hidden: hidden ?? false },
+            { "outline-1 outline-blue-700": isEdit },
+          )}
+        />
+        {initialType === "password" && (
+          <button
+            onClick={handlePasswordShow}
+            onKeyDown={onKeyDown}
+            type="button"
+            className="absolute right-0 top-44 flex h-24 w-24 -translate-x-1/2 -translate-y-1/2 items-center justify-center"
+          >
+            {<Image src={type === "password" ? "/icon/closed-eyes_black.svg" : "/icon/opened-eyes_black.svg"} alt="비밀번호 아이콘" width={16} height={16} />}
+          </button>
+        )}
+        {initialType !== "password" && !hidden && (
+          <button onClick={handleDelete} onKeyDown={onKeyDown} type="button" className="absolute right-16 top-16 h-16 w-16">
+            <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
+          </button>
+        )}
+        <div className="flex gap-8">
+          {maxLength ? <span className={classNames("mt-4 h-8", { "text-red-500": field.value.length > maxLength })}>{`(${field.value.length}/${maxLength})`}</span> : null}
+          <p className={classNames(`font-normal mt-4 h-8 text-12`, { "text-red-500": fieldState.error, "text-gray-400": !fieldState.error })}>
+            {fieldState?.error?.message || hint}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/app/_components/modal/AddressModal.tsx
+++ b/app/_components/modal/AddressModal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
+import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { PostType } from "@/(route)/post/page";
 import DaumPostcodeEmbed from "react-daum-postcode";
 import { UseFormSetValue } from "react-hook-form";
 import ModalFrame from "./ModalFrame";
 
 interface Props {
-  setValue: UseFormSetValue<PostType>;
+  setValue: UseFormSetValue<PostType> | UseFormSetValue<EditPostType>;
   closeModal: () => void;
 }
 

--- a/app/_components/modal/CalendarModal.tsx
+++ b/app/_components/modal/CalendarModal.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { PostType } from "@/(route)/post/page";
 import { format } from "date-fns";
-import { ko } from "date-fns/locale";
 import { useEffect, useState } from "react";
 import { DateRange, DayPicker } from "react-day-picker";
+import "react-day-picker/dist/style.css";
 import { UseFormSetValue } from "react-hook-form";
 import ModalFrame from "./ModalFrame";
 
 interface Props {
-  setValue: UseFormSetValue<PostType> | UseFormSetValue<EditPostType>;
+  setValue: UseFormSetValue<PostType> | any;
   closeModal: () => void;
 }
 
@@ -20,10 +19,10 @@ const CalendarModal = ({ setValue, closeModal }: Props) => {
   useEffect(() => {
     if (range?.from) {
       if (!range.to) {
-        setValue("startDate", format(range.from, "PPP EE", { locale: ko }));
+        setValue("startDate", format(range.from, "yyyy-MM-dd"));
       } else if (range.to) {
-        setValue("startDate", format(range.from, "PPP EE", { locale: ko }));
-        setValue("endDate", format(range.to, "PPP EE", { locale: ko }));
+        setValue("startDate", format(range.from, "yyyy-MM-dd"));
+        setValue("endDate", format(range.to, "yyyy-MM-dd"));
       }
     }
   }, [range]);

--- a/app/_components/modal/CalendarModal.tsx
+++ b/app/_components/modal/CalendarModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { EditPostType } from "@/(route)/event/[id]/edit/page";
 import { PostType } from "@/(route)/post/page";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
@@ -9,7 +10,7 @@ import { UseFormSetValue } from "react-hook-form";
 import ModalFrame from "./ModalFrame";
 
 interface Props {
-  setValue: UseFormSetValue<PostType>;
+  setValue: UseFormSetValue<PostType> | UseFormSetValue<EditPostType>;
   closeModal: () => void;
 }
 

--- a/app/_components/modal/EditModal.tsx
+++ b/app/_components/modal/EditModal.tsx
@@ -1,0 +1,16 @@
+import ModalFrame from "./ModalFrame";
+
+interface Props {
+  closeModal: () => void;
+}
+
+const EditModal = ({ closeModal }: Props) => {
+  return (
+    <ModalFrame closeModal={closeModal}>
+      <div>수정 요청은 사용자 3인 이상의 승인 후 반영됩니다.</div>
+      <button onClick={closeModal}>확인</button>
+    </ModalFrame>
+  );
+};
+
+export default EditModal;

--- a/app/_store/index.ts
+++ b/app/_store/index.ts
@@ -1,0 +1,8 @@
+import { create } from "zustand";
+import { WarningSlice, createWarningSlice } from "./slice/warningSlice";
+
+type SliceType = WarningSlice;
+
+export const useStore = create<SliceType>()((...a) => ({
+  ...createWarningSlice(...a),
+}));

--- a/app/_store/slice/warningSlice.ts
+++ b/app/_store/slice/warningSlice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from "zustand";
+
+export interface WarningSlice {
+  isWarningCheck: boolean;
+  setIsWarningCheck: (s: boolean) => void;
+}
+
+export const createWarningSlice: StateCreator<WarningSlice> = (set) => ({
+  isWarningCheck: false,
+  setIsWarningCheck: (s) => set((state) => ({ ...state, isWarningCheck: s })),
+});

--- a/app/_utils/editValidate.ts
+++ b/app/_utils/editValidate.ts
@@ -1,0 +1,6 @@
+import { usePathname } from "next/navigation";
+
+export const validateEdit = (condition: boolean) => {
+  const isEditPage = usePathname() !== "/post";
+  return isEditPage ? condition : false;
+};


### PR DESCRIPTION
## ✏️ 변경사항
- edit 페이지 로직 완료했습니다.
- 수정된 input에는 border가 생깁니다.
- 하나라도 값이 변경되고, 동의함까지 눌러야 버튼이 활성화됩니다.

## 📷 스크린샷
![edit](https://github.com/P1Z7/frontend/assets/103186362/6a665736-8374-4c5a-be3f-70e4cc6b42d9)

## ✍️ 사용법
### WarningCheck
이용약관 & 체크박스 포함된 UI
isCheck값은 zustand로 저장했습니다. UI는 그냥 가져가고, state 필요한 곳에 zustand 불러서 쓰면 됩니다.

## 🎸 기타
- 이미지가 url로 넘어오더라도 GET하는 시점에 file로 변환해서 클라이언트에서는 무조건 file 형식으로 가지고 있어보려고 하는데,, 흠........ api연결하면서 어떻게 해봐야할것같아요
