### PR TITLE
💄 design: 가로형 이벤트 카드 디자인 구현

### DIFF
--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -22,13 +22,13 @@ const MOCK_EVENTS = [
     eventImage: "https://thumb.mtstarnews.com/06/2023/09/2023090715013844673_1.jpg/dims/optimize",
   },
   {
-    placeName: "강남역",
+    placeName: "투썸플레이스",
     eventType: "팬광고",
     artistName: "하니",
     startDate: "2024-01-29",
     endDate: "2024-01-30",
     address: "강남구",
-    gifts: ["포토카드", "엽서"],
+    gifts: ["컵홀더", "포스터", "스티커", "티켓", "포토카드", "엽서", "굿즈", "기타"],
     eventImage: "https://thumb.mtstarnews.com/06/2023/09/2023090715013844673_1.jpg/dims/optimize",
   },
 ];

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -105,7 +105,7 @@ const SearchPage = () => {
             </button>
           </div>
         </section>
-        <section>
+        <section className="flex flex-col items-center">
           {MOCK_EVENTS.map((event, index) => (
             <HorizontalEventCard key={index} data={event} />
           ))}

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -1,5 +1,6 @@
+import Image from "next/image";
 import { EventCardType } from "@/types/index";
-import Chip from "./Chip";
+import HeartButton from "../button/HeartButton";
 
 interface Props {
   data: EventCardType;
@@ -9,31 +10,29 @@ const HorizontalEventCard = ({ data }: Props) => {
   const startDate = data.startDate.split("-");
   const endDate = data.endDate.split("-");
 
-  const formattedStartDate = `${startDate[1]}.${startDate[2]}`;
-  const formattedEndDate = `${endDate[1]}.${endDate[2]}`;
+  const formattedDate = `${startDate[1]}.${startDate[2]} ~ ${endDate[1]}.${endDate[2]}`;
 
   return (
-    <div className="flex w-320 items-center gap-12 self-stretch border-b border-solid border-[#E0E2E6] py-12">
-      <div className="h-112 w-84 bg-[#e7e7e7]" />
-      <div className="flex flex-col gap-4">
-        <p>{data.placeName}</p>
-        <div className="flex items-center gap-8">
-          <p>{data.artistName}</p>
-          <Chip chipName={data.eventType} />
+    <div className="flex w-320 gap-12 border-b border-gray-50 bg-transparent py-12">
+      <div className="relative h-112 w-84 ">
+        <Image src={data.eventImage} className="rounded-[0.4rem] object-cover" fill alt="행사 포스터" />
+      </div>
+      <div className="relative flex w-full flex-col justify-center gap-4">
+        <div className="absolute right-0 top-0">
+          <HeartButton isSmall />
         </div>
-        <div className="flex">
-          <p className="border-r border-solid border-black pr-4">
-            {formattedStartDate} ~ {formattedEndDate}
-          </p>
-          <p className="pl-4">{data.address}</p>
+        <h3 className="text-16 font-600">{data.placeName}</h3>
+        <div className="flex gap-8 text-16 font-600">
+          <span>{data.artistName}</span>
+          <div>카페</div>
         </div>
-        <div className="flex gap-4">
-          {data.gifts?.map((gift, index) => (
-            <div key={index}>
-              <Chip chipName={gift} />
-            </div>
-          ))}
-        </div>
+        <p className="text-12 font-600 text-gray-400">
+          <span className="mr-8 border-r border-gray-400 pr-8">{formattedDate}</span>
+          <span>{data.address}</span>
+        </p>
+        <ul>
+          <div>포토카드</div>
+        </ul>
       </div>
     </div>
   );

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
+import HeartButton from "@/components/button/HeartButton";
+import Chip from "@/components/chip/Chip";
 import { EventCardType } from "@/types/index";
-import HeartButton from "../button/HeartButton";
 
 interface Props {
   data: EventCardType;
@@ -13,8 +14,8 @@ const HorizontalEventCard = ({ data }: Props) => {
   const formattedDate = `${startDate[1]}.${startDate[2]} ~ ${endDate[1]}.${endDate[2]}`;
 
   return (
-    <div className="flex w-320 gap-12 border-b border-gray-50 bg-transparent py-12">
-      <div className="relative h-112 w-84 ">
+    <div className="flex w-320 items-center gap-12 border-b border-gray-50 bg-transparent py-12">
+      <div className="relative h-112 w-84 shrink-0">
         <Image src={data.eventImage} className="rounded-[0.4rem] object-cover" fill alt="행사 포스터" />
       </div>
       <div className="relative flex w-full flex-col justify-center gap-4">
@@ -22,17 +23,15 @@ const HorizontalEventCard = ({ data }: Props) => {
           <HeartButton isSmall />
         </div>
         <h3 className="text-16 font-600">{data.placeName}</h3>
-        <div className="flex gap-8 text-16 font-600">
-          <span>{data.artistName}</span>
-          <div>카페</div>
+        <div className="flex w-full gap-8">
+          <span className="text-16 font-600">{data.artistName}</span>
+          <Chip kind="event" label={data.eventType} />
         </div>
-        <p className="text-12 font-600 text-gray-400">
+        <p className="h-16 text-12 font-600 text-gray-400">
           <span className="mr-8 border-r border-gray-400 pr-8">{formattedDate}</span>
           <span>{data.address}</span>
         </p>
-        <ul>
-          <div>포토카드</div>
-        </ul>
+        <ul className="flex flex-wrap gap-4">{data.gifts?.map((gift) => <Chip kind="goods" label={gift} />)}</ul>
       </div>
     </div>
   );

--- a/app/_components/card/VerticalEventCard.tsx
+++ b/app/_components/card/VerticalEventCard.tsx
@@ -11,8 +11,7 @@ const VerticalEventCard = ({ data }: Props) => {
   const startDate = data.startDate.split("-");
   const endDate = data.endDate.split("-");
 
-  const formattedStartDate = `${startDate[1]}.${startDate[2]}`;
-  const formattedEndDate = `${endDate[1]}.${endDate[2]}`;
+  const formattedDate = `${startDate[1]}.${startDate[2]} ~ ${endDate[1]}.${endDate[2]}`;
 
   return (
     <div className="border-black flex w-148 flex-col gap-12">
@@ -33,9 +32,7 @@ const VerticalEventCard = ({ data }: Props) => {
       <div className="flex flex-col gap-4">
         <p className="truncate text-16 font-600 text-gray-900">{data.placeName}</p>
         <div className="flex gap-8 text-12 font-600 text-gray-400">
-          <p className="border-r border-gray-400 pr-8">
-            {formattedStartDate} ~ {formattedEndDate}
-          </p>
+          <p className="border-r border-gray-400 pr-8">{formattedDate}</p>
           <p>{data.address}</p>
         </div>
         <div className="flex gap-8">

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -37,13 +37,16 @@ export interface SignUpFormType {
   myArtists: string[] | [];
 }
 
+export type EventType = "카페" | "나눔" | "팬광고" | "팝업스토어" | "상영회" | "기타";
+export type GiftType = "컵홀더" | "포스터" | "스티커" | "티켓" | "포토카드" | "엽서" | "굿즈" | "기타";
+
 export interface EventCardType {
   placeName: string;
   artistName: string;
-  eventType: string;
+  eventType: EventType;
   address: string;
   startDate: string;
   endDate: string;
-  gifts?: string[];
+  gifts?: GiftType[];
   eventImage: string;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -66,7 +66,7 @@
   }
 
   body {
-    @apply text-black-white;
+    @apply text-gray-900;
   }
 }
 


### PR DESCRIPTION
## ✏️ 변경사항
- 가로형 이벤트 카드의 디자인을 구현했습니다.

## 📷 스크린샷
<img width="409" alt="스크린샷 2024-02-02 오후 6 13 34" src="https://github.com/P1Z7/frontend/assets/83965026/18a116cf-ae62-412c-a29d-5d9971307054">


## 🎸 기타
- 지금 칩 컴포넌트의 height가 피그마보다 4px 정도 큰 상태라 goods chip이 두 줄일 때 카드 컴포넌트가 조금 어긋나보이는 현상이 있습니다.