### PR TITLE
✨ feat: 바텀시트 드래그 기능 구현

### DIFF
--- a/app/(route)/(bottom-nav)/mypage/_components/UserProfile.tsx
+++ b/app/(route)/(bottom-nav)/mypage/_components/UserProfile.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const UserProfile = ({ data }: Props) => {
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();
 
   return (
     <div className="flex items-center justify-between px-20 pt-48">
@@ -25,7 +25,7 @@ const UserProfile = ({ data }: Props) => {
       <button onClick={() => openBottomSheet("mypage")}>
         <Image src="/icon/kebab-black.svg" width={24} height={25} alt="계정 정보 수정" />
       </button>
-      {bottomSheet === "mypage" && <MyPageBottomSheet closeBottomSheet={closeBottomSheet} />}
+      {bottomSheet === "mypage" && <MyPageBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} />}
     </div>
   );
 };

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -27,7 +27,7 @@ const BOTTOM_SHEET = {
 };
 
 const SearchPage = () => {
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, sheet } = useBottomSheet();
   const [filter, setFilter] = useState<FilterType>({
     bigRegion: "",
     smallRegion: "전지역",
@@ -89,7 +89,7 @@ const SearchPage = () => {
           ))}
         </section>
       </main>
-      {bottomSheet === BOTTOM_SHEET.bigRegion && <BigRegionBottomSheet closeBottomSheet={closeBottomSheet} setBigRegionFilter={setBigRegionFilter} />}
+      {bottomSheet === BOTTOM_SHEET.bigRegion && <BigRegionBottomSheet closeBottomSheet={closeBottomSheet} setBigRegionFilter={setBigRegionFilter} ref={sheet} />}
       {bottomSheet === BOTTOM_SHEET.smallRegion && (
         <SmallRegionBottomSheet closeBottomSheet={closeBottomSheet} bigRegion={filter.bigRegion as (typeof BIG_REGIONS)[number]} setSmallRegionFilter={setSmallRegionFilter} />
       )}

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -99,9 +99,9 @@ const SearchPage = () => {
         />
       )}
       {bottomSheet === BOTTOM_SHEET.calender && (
-        <CalenderBottomSheet closeBottomSheet={closeBottomSheet} setStartDateFilter={setStartDateFilter} setEndDateFilter={setEndDateFilter} />
+        <CalenderBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} setStartDateFilter={setStartDateFilter} setEndDateFilter={setEndDateFilter} />
       )}
-      {bottomSheet === BOTTOM_SHEET.gift && <GiftBottomSheet closeBottomSheet={closeBottomSheet} setGiftsFilter={setGiftsFilter} />}
+      {bottomSheet === BOTTOM_SHEET.gift && <GiftBottomSheet refs={refs} closeBottomSheet={closeBottomSheet} setGiftsFilter={setGiftsFilter} />}
     </>
   );
 };

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -27,7 +27,7 @@ const BOTTOM_SHEET = {
 };
 
 const SearchPage = () => {
-  const { bottomSheet, openBottomSheet, closeBottomSheet, sheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();
   const [filter, setFilter] = useState<FilterType>({
     bigRegion: "",
     smallRegion: "전지역",
@@ -89,9 +89,14 @@ const SearchPage = () => {
           ))}
         </section>
       </main>
-      {bottomSheet === BOTTOM_SHEET.bigRegion && <BigRegionBottomSheet closeBottomSheet={closeBottomSheet} setBigRegionFilter={setBigRegionFilter} ref={sheet} />}
+      {bottomSheet === BOTTOM_SHEET.bigRegion && <BigRegionBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} setBigRegionFilter={setBigRegionFilter} />}
       {bottomSheet === BOTTOM_SHEET.smallRegion && (
-        <SmallRegionBottomSheet closeBottomSheet={closeBottomSheet} bigRegion={filter.bigRegion as (typeof BIG_REGIONS)[number]} setSmallRegionFilter={setSmallRegionFilter} />
+        <SmallRegionBottomSheet
+          closeBottomSheet={closeBottomSheet}
+          refs={refs}
+          bigRegion={filter.bigRegion as (typeof BIG_REGIONS)[number]}
+          setSmallRegionFilter={setSmallRegionFilter}
+        />
       )}
       {bottomSheet === BOTTOM_SHEET.calender && (
         <CalenderBottomSheet closeBottomSheet={closeBottomSheet} setStartDateFilter={setStartDateFilter} setEndDateFilter={setEndDateFilter} />

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -10,7 +10,7 @@ import { PostType } from "../../page";
 
 const MainInput = () => {
   const { modal, openModal, closeModal } = useModal();
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();
   const {
     formState: { defaultValues },
     watch,
@@ -41,8 +41,8 @@ const MainInput = () => {
           </div>
         </div>
       </div>
-      {bottomSheet === "address" && <AddressBottomSheet closeBottomSheet={closeBottomSheet} />}
-      {bottomSheet === "date" && <CalenderBottomSheet closeBottomSheet={closeBottomSheet} />}
+      {bottomSheet === "address" && <AddressBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} />}
+      {bottomSheet === "date" && <CalenderBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} />}
     </>
   );
 };

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -4,7 +4,7 @@ import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 
 const StarInput = () => {
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();
 
   return (
     <>
@@ -20,8 +20,8 @@ const StarInput = () => {
           행사 유형
         </InputText>
       </div>
-      {bottomSheet === "event" && <EventTypeBottomSheet closeBottomSheet={closeBottomSheet} />}
-      {bottomSheet === "starGroup" && <StarBottomSheet closeBottomSheet={closeBottomSheet} />}
+      {bottomSheet === "event" && <EventTypeBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} />}
+      {bottomSheet === "starGroup" && <StarBottomSheet closeBottomSheet={closeBottomSheet} refs={refs} />}
     </>
   );
 };

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const Header = ({ handleClick }: Props) => {
-  const { bottomSheet, openBottomSheet, closeBottomSheet } = useBottomSheet();
+  const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();
 
   const openKebeb = () => {
     openBottomSheet("event-kebab");
@@ -38,9 +38,11 @@ const Header = ({ handleClick }: Props) => {
         )}
       </header>
       {bottomSheet === "event-kebab" && (
-        <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
-          <button>수정하기</button>
-          <button>신고히기</button>
+        <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
+          <div ref={refs.content}>
+            <button>수정하기</button>
+            <button>신고히기</button>
+          </div>
         </BottomSheet.Frame>
       )}
     </>

--- a/app/_components/bottom-sheet/AddressBottomSheet.tsx
+++ b/app/_components/bottom-sheet/AddressBottomSheet.tsx
@@ -4,13 +4,13 @@ import { useFormContext } from "react-hook-form";
 import { BottomSheetBaseType } from "@/types/index";
 import BottomSheet from "./BottomSheetMaterial";
 
-const AddressBottomSheet = ({ closeBottomSheet }: BottomSheetBaseType) => {
+const AddressBottomSheet = ({ closeBottomSheet, refs }: BottomSheetBaseType) => {
   const { setValue } = useFormContext<PostType>();
 
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>주소 검색</BottomSheet.Title>
-      <div className="w-full pt-8">
+      <div ref={refs.content} className="w-full pt-8">
         <DaumPostcodeEmbed
           className="!h-[48rem]"
           animation

--- a/app/_components/bottom-sheet/BigRegionBottomSheet.tsx
+++ b/app/_components/bottom-sheet/BigRegionBottomSheet.tsx
@@ -1,17 +1,17 @@
-import { ButtonHTMLAttributes, ReactNode, forwardRef } from "react";
+import { ButtonHTMLAttributes, ReactNode } from "react";
+import { BottomSheetBaseType } from "@/types/index";
 import { BIG_REGIONS } from "@/constants/regions";
 import BottomSheet from "./BottomSheetMaterial";
 
-interface Props {
-  closeBottomSheet: () => void;
+interface Props extends BottomSheetBaseType {
   setBigRegionFilter: (bigRegion: (typeof BIG_REGIONS)[number] | "") => void;
 }
 
-const BigRegionBottomSheet = forwardRef<HTMLDivElement, Props>(({ closeBottomSheet, setBigRegionFilter }, ref) => {
+const BigRegionBottomSheet = ({ closeBottomSheet, refs, setBigRegionFilter }: Props) => {
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={ref}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>시/도 선택</BottomSheet.Title>
-      <section className="grid grid-cols-2 gap-24 p-24">
+      <section ref={refs.content} className="grid grid-cols-2 gap-24 p-24">
         <RegionButton
           onClick={() => {
             setBigRegionFilter("");
@@ -34,7 +34,7 @@ const BigRegionBottomSheet = forwardRef<HTMLDivElement, Props>(({ closeBottomShe
       </section>
     </BottomSheet.Frame>
   );
-});
+};
 BigRegionBottomSheet.displayName = "BigRegionBottomSheet";
 
 export default BigRegionBottomSheet;

--- a/app/_components/bottom-sheet/BigRegionBottomSheet.tsx
+++ b/app/_components/bottom-sheet/BigRegionBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes, ReactNode } from "react";
+import { ButtonHTMLAttributes, ReactNode, forwardRef } from "react";
 import { BIG_REGIONS } from "@/constants/regions";
 import BottomSheet from "./BottomSheetMaterial";
 
@@ -7,9 +7,9 @@ interface Props {
   setBigRegionFilter: (bigRegion: (typeof BIG_REGIONS)[number] | "") => void;
 }
 
-const BigRegionBottomSheet = ({ closeBottomSheet, setBigRegionFilter }: Props) => {
+const BigRegionBottomSheet = forwardRef<HTMLDivElement, Props>(({ closeBottomSheet, setBigRegionFilter }, ref) => {
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={ref}>
       <BottomSheet.Title>시/도 선택</BottomSheet.Title>
       <section className="grid grid-cols-2 gap-24 p-24">
         <RegionButton
@@ -34,7 +34,8 @@ const BigRegionBottomSheet = ({ closeBottomSheet, setBigRegionFilter }: Props) =
       </section>
     </BottomSheet.Frame>
   );
-};
+});
+BigRegionBottomSheet.displayName = "BigRegionBottomSheet";
 
 export default BigRegionBottomSheet;
 

--- a/app/_components/bottom-sheet/BottomSheetMaterial.tsx
+++ b/app/_components/bottom-sheet/BottomSheetMaterial.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, SyntheticEvent } from "react";
+import { ReactNode, SyntheticEvent, forwardRef } from "react";
 import Button from "@/components/button";
 import CloseIcon from "@/public/icon/close.svg";
 import BottomSheetPortal from "./BottomSheetPortal";
@@ -10,13 +10,14 @@ interface BottomSheetFrameProps {
   closeBottomSheet: () => void;
 }
 
-const BottomSheetFrame = ({ children, closeBottomSheet }: BottomSheetFrameProps) => {
+const BottomSheetFrame = forwardRef<HTMLDivElement, BottomSheetFrameProps>(({ children, closeBottomSheet }, ref) => {
   return (
     <BottomSheetPortal>
       <div onClick={closeBottomSheet} className="fixed bottom-0 left-0 z-popup flex h-screen w-full items-end justify-center bg-gray-900 bg-opacity-70">
         <div
+          ref={ref}
           onClick={(e: SyntheticEvent) => e.stopPropagation()}
-          className="relative flex max-h-[55.6rem] w-full animate-slideUp flex-col overflow-y-auto rounded-t-md bg-white-black pt-16"
+          className="relative flex max-h-[55.6rem] w-full transform animate-slideUp flex-col overflow-y-auto rounded-t-md bg-white-black pt-16 transition duration-150 ease-out"
         >
           <button onClick={closeBottomSheet} className="absolute right-20 top-16">
             <CloseIcon stroke="#C1C5CC" width="24" height="24" />
@@ -26,7 +27,8 @@ const BottomSheetFrame = ({ children, closeBottomSheet }: BottomSheetFrameProps)
       </div>
     </BottomSheetPortal>
   );
-};
+});
+BottomSheetFrame.displayName = "BottomSheetFrame";
 
 interface BottomSheetTitleProps {
   children: ReactNode;

--- a/app/_components/bottom-sheet/CalendarBottomSheet.tsx
+++ b/app/_components/bottom-sheet/CalendarBottomSheet.tsx
@@ -1,24 +1,24 @@
 "use client";
 
 import { PostType } from "@/(route)/post/page";
-import "@/styles/customCalendar.css";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useEffect, useState } from "react";
 import { DateRange, DayPicker } from "react-day-picker";
 import { useFormContext } from "react-hook-form";
+import { BottomSheetBaseType } from "@/types/index";
 import { CALENDAR_STYLE } from "@/constants/calendarStyle";
+import "@/styles/customCalendar.css";
 import BottomSheet from "./BottomSheetMaterial";
 
-interface Props {
-  closeBottomSheet: () => void;
+interface Props extends BottomSheetBaseType {
   setStartDateFilter?: (data: string) => void;
   setEndDateFilter?: (date: string) => void;
 }
 
 // TODO: 값 설정을 버튼이 눌렸을 때로 수정 필요
 
-const CalenderBottomSheet = ({ closeBottomSheet, setStartDateFilter, setEndDateFilter }: Props) => {
+const CalenderBottomSheet = ({ closeBottomSheet, refs, setStartDateFilter, setEndDateFilter }: Props) => {
   const { setValue } = useFormContext<PostType>();
   const [range, setRange] = useState<DateRange | undefined>();
 
@@ -46,9 +46,9 @@ const CalenderBottomSheet = ({ closeBottomSheet, setStartDateFilter, setEndDateF
   return (
     <>
       <style>{CALENDAR_STYLE}</style>
-      <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+      <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
         <BottomSheet.Title>날짜 선택</BottomSheet.Title>
-        <div className="flex w-full justify-center">
+        <div className="flex w-full justify-center" ref={refs.content}>
           <DayPicker
             weekStartsOn={1}
             id="test"

--- a/app/_components/bottom-sheet/EventTypeBottomSheet.tsx
+++ b/app/_components/bottom-sheet/EventTypeBottomSheet.tsx
@@ -5,7 +5,7 @@ import BottomSheet from "./BottomSheetMaterial";
 
 const EVENT_TYPE_LIST = ["카페", "나눔", "팬광고", "팝업스토어", "상영회", "기타"];
 
-const EventTypeBottomSheet = ({ closeBottomSheet }: BottomSheetBaseType) => {
+const EventTypeBottomSheet = ({ closeBottomSheet, refs }: BottomSheetBaseType) => {
   const { setValue } = useFormContext<PostType>();
 
   const handleEventClick = (type: string) => {
@@ -14,9 +14,9 @@ const EventTypeBottomSheet = ({ closeBottomSheet }: BottomSheetBaseType) => {
   };
 
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>행사 유형 선택</BottomSheet.Title>
-      <ul className="pb-40">
+      <ul className="pb-40" ref={refs.content}>
         {EVENT_TYPE_LIST.map((event) => (
           <li
             key={event}

--- a/app/_components/bottom-sheet/GiftsBottomSheet.tsx
+++ b/app/_components/bottom-sheet/GiftsBottomSheet.tsx
@@ -1,16 +1,18 @@
+import { BottomSheetBaseType } from "@/types/index";
 import BottomSheet from "./BottomSheetMaterial";
 
-interface Props {
-  closeBottomSheet: () => void;
+interface Props extends BottomSheetBaseType {
   setGiftsFilter: (gift: string) => void;
 }
 
-const GiftsBottomSheet = ({ closeBottomSheet, setGiftsFilter }: Props) => {
+const GiftsBottomSheet = ({ closeBottomSheet, refs, setGiftsFilter }: Props) => {
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>특전 선택</BottomSheet.Title>
-      <button onClick={() => setGiftsFilter("포토카드")}>포토카드</button>
-      <BottomSheet.Button onClick={closeBottomSheet} />
+      <div ref={refs.content}>
+        <button onClick={() => setGiftsFilter("포토카드")}>포토카드</button>
+        <BottomSheet.Button onClick={closeBottomSheet} />
+      </div>
     </BottomSheet.Frame>
   );
 };

--- a/app/_components/bottom-sheet/MyPageBottomSheet.tsx
+++ b/app/_components/bottom-sheet/MyPageBottomSheet.tsx
@@ -1,9 +1,6 @@
 import { useRouter } from "next/navigation";
+import { BottomSheetBaseType } from "@/types/index";
 import BottomSheet from "./BottomSheetMaterial";
-
-interface Props {
-  closeBottomSheet: () => void;
-}
 
 const EditUserInfo = {
   profile: "프로필수정",
@@ -12,11 +9,11 @@ const EditUserInfo = {
   withdrawal: "회원탈퇴",
 };
 
-const MyPageBottomSheet = ({ closeBottomSheet }: Props) => {
+const MyPageBottomSheet = ({ closeBottomSheet, refs }: BottomSheetBaseType) => {
   const router = useRouter();
 
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <div className="flex flex-col gap-20 p-20 text-16" onClick={(event) => event.stopPropagation()}>
         <button onClick={() => router.push("/setting/profile")}>{EditUserInfo.profile}</button>
         <button onClick={() => router.push("/setting/password")}>{EditUserInfo.password}</button>

--- a/app/_components/bottom-sheet/SmallRegionBottomSheet.tsx
+++ b/app/_components/bottom-sheet/SmallRegionBottomSheet.tsx
@@ -1,18 +1,18 @@
 import { ButtonHTMLAttributes, ReactNode } from "react";
+import { BottomSheetBaseType } from "@/types/index";
 import { BIG_REGIONS, SMALL_REGIONS } from "@/constants/regions";
 import BottomSheet from "./BottomSheetMaterial";
 
-interface Props {
-  closeBottomSheet: () => void;
+interface Props extends BottomSheetBaseType {
   bigRegion: (typeof BIG_REGIONS)[number];
   setSmallRegionFilter: (bigRegion: string) => void;
 }
 
-const SmallRegionBottomSheet = ({ closeBottomSheet, bigRegion, setSmallRegionFilter }: Props) => {
+const SmallRegionBottomSheet = ({ closeBottomSheet, refs, bigRegion, setSmallRegionFilter }: Props) => {
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>시/군/구 선택</BottomSheet.Title>
-      <section className="grid grid-cols-2 gap-24 p-24">
+      <section ref={refs.content} className="grid grid-cols-2 gap-24 p-24">
         <RegionButton
           onClick={() => {
             setSmallRegionFilter("전지역");

--- a/app/_components/bottom-sheet/StarBottomSheet.tsx
+++ b/app/_components/bottom-sheet/StarBottomSheet.tsx
@@ -9,7 +9,7 @@ import ArtistCard from "../ArtistCard";
 import SearchInput from "../input/SearchInput";
 import BottomSheet from "./BottomSheetMaterial";
 
-const StarBottomSheet = ({ closeBottomSheet }: BottomSheetBaseType) => {
+const StarBottomSheet = ({ closeBottomSheet, refs }: BottomSheetBaseType) => {
   const [groupId, setgroupId] = useState(""); //선택한 그룹 아이디
   const [keyword, setKeyword] = useState("");
   const { setValue } = useFormContext<PostType>();
@@ -68,9 +68,9 @@ const StarBottomSheet = ({ closeBottomSheet }: BottomSheetBaseType) => {
   // console.log(groupData);
 
   return (
-    <BottomSheet.Frame closeBottomSheet={closeBottomSheet}>
+    <BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
       <BottomSheet.Title>아티스트 선택</BottomSheet.Title>
-      <div className="flex flex-col gap-20 px-24 pt-16 text-16" onClick={(event) => event.stopPropagation()}>
+      <div className="flex flex-col gap-20 px-24 pt-16 text-16" onClick={(event) => event.stopPropagation()} ref={refs.content}>
         {groupId ? (
           <>
             {/* {isMemberLoading && <div>멤버 로딩중</div>}

--- a/app/_hooks/useBottomSheet.tsx
+++ b/app/_hooks/useBottomSheet.tsx
@@ -1,15 +1,84 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export const useBottomSheet = () => {
+interface BottomSheetMetrics {
+  touchStart: {
+    sheetY: number;
+    touchY: number;
+  };
+  snap: number;
+}
+
+export function useBottomSheet() {
   const [bottomSheet, setBottomSheet] = useState("");
 
   const openBottomSheet = (type: string) => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
     setBottomSheet(type);
   };
 
   const closeBottomSheet = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+    }
     setBottomSheet("");
   };
 
-  return { bottomSheet, openBottomSheet, closeBottomSheet };
-};
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: {
+      sheetY: 0,
+      touchY: 0,
+    },
+    snap: 0,
+  });
+  const timer = useRef<NodeJS.Timeout>();
+
+  const sheet = useCallback((node: HTMLElement) => {
+    if (node !== null) {
+      const handleTouchStart = (e: TouchEvent) => {
+        const { touchStart } = metrics.current;
+
+        touchStart.sheetY = node.getBoundingClientRect().y;
+        touchStart.touchY = e.touches[0].clientY;
+        metrics.current.snap = touchStart.sheetY + node.getBoundingClientRect().height / 2;
+      };
+
+      const handleTouchMove = (e: TouchEvent) => {
+        const { touchStart } = metrics.current;
+        const currentTouch = e.touches[0];
+
+        const touchOffset = currentTouch.clientY - touchStart.touchY;
+        node.style.setProperty("transform", `translateY(${touchOffset > 0 ? touchOffset : 0}px)`);
+      };
+
+      const handleTouchEnd = (e: TouchEvent) => {
+        const { touchStart, snap } = metrics.current;
+        const currentY = node.getBoundingClientRect().y;
+
+        if (currentY > snap) {
+          node.style.setProperty("transform", `translateY(${touchStart.sheetY}px)`);
+          timer.current = setInterval(closeBottomSheet, 100);
+        }
+
+        if (currentY < snap) {
+          node.style.setProperty("transform", `translateY(${0}px)`);
+        }
+      };
+
+      node.addEventListener("touchstart", handleTouchStart);
+      node.addEventListener("touchmove", handleTouchMove);
+      node.addEventListener("touchend", handleTouchEnd);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!bottomSheet) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [bottomSheet]);
+
+  return { bottomSheet, openBottomSheet, closeBottomSheet, sheet };
+}

--- a/app/_hooks/useBottomSheet.tsx
+++ b/app/_hooks/useBottomSheet.tsx
@@ -62,7 +62,7 @@ export function useBottomSheet() {
         const currentY = node.getBoundingClientRect().y;
 
         if (currentY > snap) {
-          node.style.setProperty("transform", `translateY(${touchStart.sheetY}px)`);
+          node.style.setProperty("transform", `translateY(${window.innerHeight - touchStart.sheetY}px)`);
           timer.current = setInterval(closeBottomSheet, 100);
         }
         if (currentY < snap) {
@@ -82,7 +82,6 @@ export function useBottomSheet() {
     if (node !== null) {
       const handleTouchStart = () => {
         metrics.current.isContentAreaTouched = true;
-        console.log("CONTENT");
       };
 
       node.addEventListener("touchstart", handleTouchStart);

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -1,11 +1,16 @@
-import { ReactElement, ReactNode } from "react";
+import { ReactElement, ReactNode, RefObject } from "react";
 
 export interface ModalBaseType {
   closeModal: () => void;
 }
 
+type BottomSheetRefs = {
+  sheet: (node: HTMLElement | null) => void;
+  content: (node: HTMLElement | null) => void;
+};
 export interface BottomSheetBaseType {
   closeBottomSheet: () => void;
+  refs: BottomSheetRefs;
 }
 export interface MapType {
   name: string;


### PR DESCRIPTION
## ✏️ 변경사항
바텀시트에 드래그 기능을 추가했습니다.

## 📷 스크린샷

https://github.com/P1Z7/frontend/assets/83965026/d8977f1c-c1c1-4525-86df-511dd1c139b9


## ✍️ 사용법
기존의 사용법에서 `refs`가 추가되었습니다.
`BottomSheet.Frame`에 `ref`로 `refs.sheet`를 전달해주고, 드래그를 원하지 않는 컨텐츠 영역에는 `refs.content`를 전달해주면 됩니다.

```tsx
const { bottomSheet, openBottomSheet, closeBottomSheet, refs } = useBottomSheet();


<BottomSheet.Frame closeBottomSheet={closeBottomSheet} ref={refs.sheet}>
    <BottomSheet.Title>...</BottomSheet.Title>
    <section ref={refs.content}>
      ...
    </section>
</BottomSheet.Frame>
```
