### PR TITLE
🩹 chore: 행사 상세 설명 위치 및 디자인 수정

### DIFF
--- a/app/(route)/(header)/event/[id]/_components/tab/DescriptionTab.tsx
+++ b/app/(route)/(header)/event/[id]/_components/tab/DescriptionTab.tsx
@@ -10,8 +10,8 @@ interface Props {
 const DescriptionTab = ({ images, description }: Props) => {
   return (
     <div className="mb-40 flex w-full flex-col gap-16 px-20 py-24 pt-24">
+      <p className="whitespace-pre-wrap text-14 font-500">{description}</p>
       {images?.map((image) => <Image key={image} src={image} alt={"행사 정보 사진"} width={0} height={0} sizes="100vw" className="w-full" />)}
-      <p className="text-14 font-500">{description}</p>
     </div>
   );
 };


### PR DESCRIPTION
## ✏️ 변경사항
- 행사 상세 페이지의 상세 설명 위치 및 클래스명을 수정했습니다.

## 📷 스크린샷
<img width="433" alt="스크린샷 2024-02-06 오후 5 21 54" src="https://github.com/P1Z7/frontend/assets/83965026/01596983-f42a-48e3-93c3-2692ea5002ea">
