### PR TITLE
♻️ refactor: api함수 타입 자동 추론되도록 수정

### DIFF
--- a/app/_components/bottom-sheet/StarBottomSheet.tsx
+++ b/app/_components/bottom-sheet/StarBottomSheet.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { Api } from "@/api/api";
 import { BottomSheetBaseType } from "@/types/index";
-import { Req_Post_Type } from "@/types/reqType";
 import ArtistCard from "../ArtistCard";
 import SearchInput from "../input/SearchInput";
 import BottomSheet from "./BottomSheetMaterial";
@@ -22,8 +21,8 @@ const StarBottomSheet = ({ closeBottomSheet, refs }: BottomSheetBaseType) => {
   } = useQuery({
     queryKey: ["group"],
     queryFn: async () => {
-      return instance.get("/group/solo", { size: 12, page: 1 });
-      // return instance.post<Req_Post_Type["signup"]>("/users", {
+      return instance.get("/group/solo", { page: 1, size: 12 });
+      // return instance.post("/users", {
       //   userName: "",
       //   signupMethod: "opener",
       //   email: "post@test.com",

--- a/app/_types/queryType.ts
+++ b/app/_types/queryType.ts
@@ -1,0 +1,45 @@
+type Req_Query_Event = {
+  keyword?: string;
+  sido?: string;
+  gungu?: string;
+  startDate?: string;
+  endDate?: string;
+  tags?: string;
+  page?: number;
+  size?: number;
+};
+
+type Req_Query_Event_Detail = {
+  eventId: string;
+};
+
+type Req_Query_Artist_And_Group = {
+  keyword?: string;
+  page?: number;
+  size?: number;
+};
+
+type Req_Query_Member = {
+  id: string;
+};
+
+type Req_Query_Group_And_Solo = {
+  size?: number;
+  page?: number;
+  keyword?: string;
+};
+
+type Req_Query_Review = {
+  size: number;
+  cursorId: number;
+  eventId: string;
+};
+
+export type Req_Query_Type = {
+  행사목록: Req_Query_Event;
+  행사상세: Req_Query_Event_Detail;
+  아티스트: Req_Query_Artist_And_Group;
+  멤버: Req_Query_Member;
+  그룹솔로: Req_Query_Group_And_Solo;
+  리뷰: Req_Query_Review;
+};

--- a/app/_types/reqPostType.ts
+++ b/app/_types/reqPostType.ts
@@ -62,6 +62,12 @@ type Req_Post_Review = {
   isAgree?: boolean;
 };
 
+type Req_Post_Review_Like = {
+  reviewId: string;
+  userId: string;
+  isLike: boolean;
+};
+
 export type Req_Post_Type = {
   event: Req_Post_Event;
   signup: Req_Post_Signup;
@@ -70,4 +76,5 @@ export type Req_Post_Type = {
   artist: Req_Post_Artist;
   group: Req_Post_Group;
   review: Req_Post_Review;
+  reviewLike: Req_Post_Review_Like;
 };


### PR DESCRIPTION
## ✏️ 변경사항
- api함수에 제네릭을 넣지 않고, endPoint 입력시 알아서 쿼리와 바디의 타입이 자동추론됩니다.

## 📷 스크린샷

## ✍️ 사용법

## 🎸 기타
- 건우님 리뷰를 이제야 확인하는 바람에 늦은 수정 죄송합니다 ㅠ_ㅠ
- 참고로 put/delete는 api가 나온게 하나도 없어서,, 나오면 타입을 나중에 다시 지정해야할것같아요.......
- 해당 pr 머지되면 제 post api(이전 방식 사용) 쪽에서 컨플릭트가 날거라서 이거 먼저 우선적으로 머지 부탁드립니다 !!!!!
