### PR TITLE
fix : ChipButton, InputText

### DIFF
--- a/app/(route)/(header)/setting/favorite/page.tsx
+++ b/app/(route)/(header)/setting/favorite/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MOCK } from "app/_constants/mock";
-import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import MyArtistList from "@/components/MyArtistList";
 import AlertModal from "@/components/modal/AlertModal";
 import InputModal from "@/components/modal/InputModal";
@@ -9,8 +9,14 @@ import { useModal } from "@/hooks/useModal";
 
 const FavoritePage = () => {
   const { modal, openModal, closeModal } = useModal();
-  const { control } = useForm({ defaultValues: { search: "" } });
+  const { control, handleSubmit, setValue } = useForm({ defaultValues: { request: "" } });
 
+  const onSubmit: SubmitHandler<{ request: string }> = ({ request }) => {
+    if (request) {
+      openModal("confirm");
+      setValue("request", "");
+    }
+  };
   return (
     <>
       <div className="flex flex-col gap-24 px-20 py-36">
@@ -27,9 +33,9 @@ const FavoritePage = () => {
           title="아티스트 등록 요청"
           label=""
           btnText="요청하기"
-          handleBtnClick={() => openModal("confirm")}
+          handleBtnClick={handleSubmit(onSubmit)}
           closeModal={closeModal}
-          {...{ placeholder: "찾으시는 아티스트를 알려주세요.", rules: { required: "내용을 입력하세요." }, control: control }}
+          {...{ name: "request", placeholder: "찾으시는 아티스트를 알려주세요.", rules: { required: "내용을 입력하세요." }, control, noButton: true }}
         />
       )}
       {modal === "confirm" && <AlertModal closeModal={closeModal}>등록 요청이 제출되었습니다.</AlertModal>}

--- a/app/(route)/(header)/setting/favorite/page.tsx
+++ b/app/(route)/(header)/setting/favorite/page.tsx
@@ -31,7 +31,6 @@ const FavoritePage = () => {
       {modal === "noArtist" && (
         <InputModal
           title="아티스트 등록 요청"
-          label=""
           btnText="요청하기"
           handleBtnClick={handleSubmit(onSubmit)}
           closeModal={closeModal}

--- a/app/_components/MyArtistList.tsx
+++ b/app/_components/MyArtistList.tsx
@@ -26,7 +26,7 @@ const MyArtistList = ({ data }: Props) => {
         <SearchInput setKeyword={setKeyword} placeholder="최애의 행사를 찾아보세요!" />
         <div className="flex w-full gap-12 overflow-auto">
           {selected.map((artist) => (
-            <ChipButton label={artist} key={artist} onDelete={() => handleArtistClick(artist)} />
+            <ChipButton label={artist} key={artist} onClick={() => handleArtistClick(artist)} canDelete />
           ))}
         </div>
       </section>

--- a/app/_components/chip/ChipButton.tsx
+++ b/app/_components/chip/ChipButton.tsx
@@ -3,7 +3,7 @@
 import { MouseEvent, useState } from "react";
 import CloseIcon from "@/public/icon/close.svg";
 
-type Handler = "onClick" | "onDelete";
+type Handler = "onDelete";
 type MappedHandler = {
   [key in Handler]?: (e?: MouseEvent) => void;
 };
@@ -13,14 +13,8 @@ interface Props extends MappedHandler {
   selected?: boolean;
 }
 
-const ChipButton = ({ label, selected: initial = false, onClick, onDelete }: Props) => {
+const ChipButton = ({ label, selected: initial = false, onDelete }: Props) => {
   const [isDelete, setIsDelete] = useState(false);
-  const handleClick = (e: MouseEvent) => {
-    e.preventDefault();
-    if (onClick) {
-      onClick(e);
-    }
-  };
 
   const handleDelete = (e: MouseEvent) => {
     setIsDelete(true);
@@ -34,9 +28,9 @@ const ChipButton = ({ label, selected: initial = false, onClick, onDelete }: Pro
   }
 
   return (
-    <button onClick={handleClick} className="flex-center w-max flex-shrink-0 gap-4 rounded-lg bg-gray-50 px-12 py-4 text-gray-700">
+    <button onClick={handleDelete} className="flex-center border-main-pink-300 text-main-pink-white w-max flex-shrink-0 gap-4 rounded-lg border bg-sub-pink-bg px-12 py-4">
       <p className="text-14 font-500">{label}</p>
-      {!!onDelete && <CloseIcon onClick={handleDelete} alt="태그 삭제" width={16} height={16} stroke="#A0A5B1" />}
+      {!!onDelete && <CloseIcon alt="태그 삭제" width={16} height={16} stroke="#FF50AA" />}
     </button>
   );
 };

--- a/app/_components/chip/ChipButton.tsx
+++ b/app/_components/chip/ChipButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, Ref, RefObject, forwardRef } from "react";
 import CloseIcon from "@/public/icon/close.svg";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -9,9 +9,10 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   canDelete?: boolean;
 }
 
-const ChipButton = ({ label, selected, canDelete, ...rest }: Props) => {
+const ChipButton = forwardRef(({ label, selected, canDelete, ...rest }: Props, ref: Ref<HTMLButtonElement>) => {
   return (
     <button
+      ref={ref}
       {...rest}
       className={`flex-center w-max flex-shrink-0 gap-4 rounded-lg px-12 py-4  ${canDelete && "border border-main-pink-300 bg-sub-pink-bg text-main-pink-white"} ${selected ? "bg-gray-900 text-white-black" : "bg-gray-50 text-gray-700"}`}
     >
@@ -19,5 +20,5 @@ const ChipButton = ({ label, selected, canDelete, ...rest }: Props) => {
       {canDelete && <CloseIcon alt="태그 삭제" width={16} height={16} stroke="#FF50AA" />}
     </button>
   );
-};
+});
 export default ChipButton;

--- a/app/_components/chip/ChipButton.tsx
+++ b/app/_components/chip/ChipButton.tsx
@@ -14,11 +14,9 @@ interface Props extends MappedHandler {
 }
 
 const ChipButton = ({ label, selected: initial = false, onClick, onDelete }: Props) => {
-  const [selected, setSelected] = useState(initial);
   const [isDelete, setIsDelete] = useState(false);
   const handleClick = (e: MouseEvent) => {
     e.preventDefault();
-    setSelected((prev) => !prev);
     if (onClick) {
       onClick(e);
     }
@@ -36,12 +34,9 @@ const ChipButton = ({ label, selected: initial = false, onClick, onDelete }: Pro
   }
 
   return (
-    <button
-      onClick={handleClick}
-      className={`flex-center w-max flex-shrink-0 gap-4 rounded-lg px-12 py-4 ${selected ? "bg-gray-900 text-white-black" : "bg-gray-50 text-gray-700"}`}
-    >
+    <button onClick={handleClick} className="flex-center w-max flex-shrink-0 gap-4 rounded-lg bg-gray-50 px-12 py-4 text-gray-700">
       <p className="text-14 font-500">{label}</p>
-      {!!onDelete && <CloseIcon onClick={handleDelete} alt="태그 삭제" width={16} height={16} stroke={selected ? "#FFF" : "#A0A5B1"} />}
+      {!!onDelete && <CloseIcon onClick={handleDelete} alt="태그 삭제" width={16} height={16} stroke="#A0A5B1" />}
     </button>
   );
 };

--- a/app/_components/chip/ChipButton.tsx
+++ b/app/_components/chip/ChipButton.tsx
@@ -1,36 +1,22 @@
 "use client";
 
-import { MouseEvent, useState } from "react";
+import { ButtonHTMLAttributes } from "react";
 import CloseIcon from "@/public/icon/close.svg";
 
-type Handler = "onDelete";
-type MappedHandler = {
-  [key in Handler]?: (e?: MouseEvent) => void;
-};
-
-interface Props extends MappedHandler {
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   selected?: boolean;
+  canDelete?: boolean;
 }
 
-const ChipButton = ({ label, selected: initial = false, onDelete }: Props) => {
-  const [isDelete, setIsDelete] = useState(false);
-
-  const handleDelete = (e: MouseEvent) => {
-    setIsDelete(true);
-    if (onDelete) {
-      onDelete(e);
-    }
-  };
-
-  if (isDelete) {
-    return null;
-  }
-
+const ChipButton = ({ label, selected, canDelete, ...rest }: Props) => {
   return (
-    <button onClick={handleDelete} className="flex-center border-main-pink-300 text-main-pink-white w-max flex-shrink-0 gap-4 rounded-lg border bg-sub-pink-bg px-12 py-4">
+    <button
+      {...rest}
+      className={`flex-center w-max flex-shrink-0 gap-4 rounded-lg px-12 py-4  ${canDelete && "border border-main-pink-300 bg-sub-pink-bg text-main-pink-white"} ${selected ? "bg-gray-900 text-white-black" : "bg-gray-50 text-gray-700"}`}
+    >
       <p className="text-14 font-500">{label}</p>
-      {!!onDelete && <CloseIcon alt="태그 삭제" width={16} height={16} stroke="#FF50AA" />}
+      {canDelete && <CloseIcon alt="태그 삭제" width={16} height={16} stroke="#FF50AA" />}
     </button>
   );
 };

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -1,22 +1,17 @@
 import classNames from "classnames";
 import Image from "next/image";
-import { KeyboardEvent, ReactNode, useState } from "react";
+import { InputHTMLAttributes, KeyboardEvent, ReactNode, useCallback, useMemo, useState } from "react";
 import { FieldPath, FieldValues, UseControllerProps, useController } from "react-hook-form";
 
-interface Prop {
+interface Prop extends InputHTMLAttributes<HTMLInputElement> {
   children?: ReactNode;
   type?: "text" | "password";
   horizontal?: boolean;
-  placeholder?: string;
-  autoComplete?: string;
   hint?: string;
-  hidden?: boolean;
-  readOnly?: boolean;
-  required?: boolean;
-  disabled?: boolean;
   onKeyDown?: (e: KeyboardEvent) => void;
   onClick?: () => void;
   isEdit?: boolean;
+  noButton?: boolean;
 }
 
 type Function = <TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>>(
@@ -37,6 +32,7 @@ const InputText: Function = ({
   onClick,
   onKeyDown,
   isEdit,
+  noButton,
   ...control
 }) => {
   const { field, fieldState } = useController(control);
@@ -50,20 +46,53 @@ const InputText: Function = ({
     field.onChange("");
   };
 
-  return (
-    <div className={`${horizontal && "flex gap-28"}`}>
-      {children && (
+  const Label = useCallback(() => {
+    if (children) {
+      return (
         <label htmlFor={field.name} className={`text-16 ${horizontal && "mt-20"}`}>
           {children}
           <span className="ml-4 text-red">{required && "*"}</span>
         </label>
-      )}
+      );
+    }
+  }, []);
+
+  const Button = useCallback(() => {
+    if (noButton || hidden) {
+      return null;
+    }
+    if (initialType === "password") {
+      return (
+        <button onClick={handlePasswordShow} onKeyDown={onKeyDown} type="button" className="flex-center absolute right-16 top-20 h-24 w-24">
+          {<Image src={type === "password" ? "/icon/closed-eyes_black.svg" : "/icon/opened-eyes_black.svg"} alt="비밀번호 아이콘" width={16} height={16} />}
+        </button>
+      );
+    }
+    return (
+      <button onClick={handleDelete} onKeyDown={onKeyDown} type="button" className="absolute right-16 top-24 h-16 w-16">
+        <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
+      </button>
+    );
+  }, []);
+
+  const ErrorField = useCallback(() => {
+    return (
+      <div className="mt-4 flex h-12">
+        {(!!fieldState.error || hint) && <p className={`font-normal text-12 ${fieldState.error ? "text-red" : "text-gray-500"}`}>{fieldState?.error?.message || hint}</p>}
+      </div>
+    );
+  }, [fieldState.error]);
+
+  return (
+    <div className={`${horizontal && "flex gap-28"}`}>
+      <Label />
       <div className={`relative ${horizontal && "flex-1"}`}>
         <input
           id={field.name}
           type={type}
           placeholder={placeholder ?? "입력해주세요."}
           autoComplete={autoComplete ?? "off"}
+          hidden={hidden ?? false}
           readOnly={readOnly ?? false}
           disabled={disabled ?? false}
           onClick={onClick}
@@ -72,25 +101,11 @@ const InputText: Function = ({
           className={classNames(
             "focus:border-1 mt-8 h-48 w-full rounded-sm bg-gray-50 px-16 py-12 pr-36 text-16 text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-1 focus:outline-blue",
             { "outline outline-1 outline-red": fieldState.error },
-            { hidden: hidden ?? false },
             { "outline outline-1 outline-blue": isEdit },
           )}
         />
-        {initialType === "password" && (
-          <button onClick={handlePasswordShow} onKeyDown={onKeyDown} type="button" className="flex-center absolute right-16 top-20 h-24 w-24">
-            {<Image src={type === "password" ? "/icon/closed-eyes_black.svg" : "/icon/opened-eyes_black.svg"} alt="비밀번호 아이콘" width={16} height={16} />}
-          </button>
-        )}
-        {initialType !== "password" && !hidden && (
-          <button onClick={handleDelete} onKeyDown={onKeyDown} type="button" className="absolute right-16 top-24 h-16 w-16">
-            <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
-          </button>
-        )}
-        {(fieldState.error || hint) && (
-          <div className="flex gap-8">
-            <p className={`font-normal h-18 mt-4 text-12 ${fieldState.error ? "text-red" : "text-gray-500"}`}>{fieldState?.error?.message || hint}</p>
-          </div>
-        )}
+        <Button />
+        <ErrorField />
       </div>
     </div>
   );

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -10,7 +10,6 @@ interface Prop {
   placeholder?: string;
   autoComplete?: string;
   hint?: string;
-  maxLength?: number;
   hidden?: boolean;
   readOnly?: boolean;
   required?: boolean;
@@ -31,7 +30,6 @@ const InputText: Function = ({
   placeholder,
   autoComplete,
   hint,
-  maxLength,
   hidden,
   required,
   readOnly,
@@ -88,9 +86,8 @@ const InputText: Function = ({
             <Image src="/icon/x_gray.svg" alt="초기화 버튼" width={16} height={16} />
           </button>
         )}
-        {(maxLength || fieldState.error || hint) && (
+        {(fieldState.error || hint) && (
           <div className="flex gap-8">
-            {maxLength ? <span className={classNames("mt-4 h-8", { "text-red": field.value.length > maxLength })}>{`(${field.value.length}/${maxLength})`}</span> : null}
             <p className={`font-normal h-18 mt-4 text-12 ${fieldState.error ? "text-red" : "text-gray-500"}`}>{fieldState?.error?.message || hint}</p>
           </div>
         )}

--- a/app/_components/modal/InputModal.tsx
+++ b/app/_components/modal/InputModal.tsx
@@ -7,6 +7,7 @@ interface Props extends ModalBaseType {
   label: string;
   btnText: string;
   handleBtnClick?: () => void;
+  name: string;
 }
 
 /**
@@ -18,9 +19,7 @@ const InputModal = ({ title, label, closeModal, handleBtnClick, btnText, ...prop
   return (
     <Modal.Frame closeModal={closeModal}>
       <Modal.Title>{title}</Modal.Title>
-      <InputText name={label} {...props}>
-        {label}
-      </InputText>
+      <InputText {...props}>{label}</InputText>
       <Modal.Button handleYesClick={handleBtnClick || closeModal}>{btnText}</Modal.Button>
     </Modal.Frame>
   );

--- a/app/_components/modal/InputModal.tsx
+++ b/app/_components/modal/InputModal.tsx
@@ -4,7 +4,7 @@ import Modal from "./ModalMaterial";
 
 interface Props extends ModalBaseType {
   title: string;
-  label: string;
+  label?: string;
   btnText: string;
   handleBtnClick?: () => void;
   name: string;


### PR DESCRIPTION
## ✏️ 변경사항
- [x] ChipButton에서 삭제와 선택 시의 동작 구분
- [x] ChipButton에서 삭제는 `canDelete` 프롭으로 구분
- [x] InputText에서 버튼을 안 보이게하는 `noButton` 프롭 추가  

## 📷 스크린샷
### ChipButton canDelete=false
![image](https://github.com/P1Z7/frontend/assets/78120157/00d08cf0-949e-46dc-ad7a-0c7e9823c95a)
### ChipButton canDelete=true
![image](https://github.com/P1Z7/frontend/assets/78120157/d5cd18d9-6b43-4443-825b-814b4dd4d400)
### noButton
![nobutton](https://github.com/P1Z7/frontend/assets/78120157/8c8ee2e8-7320-43a9-adc7-b047dbe80971)

## ✍️ 사용법
버튼 클릭 시 삭제가 필요할 때, 
```ts
<ChipButton canDelete />
```
InputText에서 버튼이 필요없을 때,
```ts
<InputText noButton />
```
## 🎸 기타
