### PR TITLE
♻️ refactor: post submit 관련 함수 util로 분리

### DIFF
--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { Dispatch, SetStateAction } from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import InputFile from "@/components/input/InputFile";
 import CloseIcon from "@/public/icon/close.svg";
 
@@ -10,33 +10,25 @@ interface Props {
 
 const ImageSection = ({ imgList, setImgList }: Props) => {
   return (
-    <div className="flex flex-col gap-8">
-      <div>이미지</div>
-      <div className="flex gap-8 overflow-x-scroll scrollbar-hide">
-        {imgList.length < 5 && <InputFile name="eventImages" />}
-        <div className="flex gap-8">
-          {Array.from(imgList).map((file, idx) => (
-            <div key={idx} className="relative flex h-120 w-120 shrink-0">
-              <button
-                onClick={() => setImgList((prev) => prev.filter((item) => item !== file))}
-                type="button"
-                className="absolute right-4 top-4 z-nav flex h-24 w-24 cursor-pointer items-center justify-center rounded-full bg-gray-900 bg-opacity-65"
-              >
-                <CloseIcon width="20" height="20" stroke="#FFFFFF" />
-              </button>
-              {idx === 0 && <span className="absolute left-4 top-4 z-nav rounded-[0.8rem] bg-[#000000]/[.72] px-8 py-4 text-12 text-white-white">대표이미지</span>}
-              <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 이미지 미리보기" fill className="object-cover" />
-            </div>
-          ))}
-        </div>
+    <div className="flex gap-8 overflow-x-scroll scrollbar-hide">
+      {imgList.length < 5 && <InputFile name="eventImages" />}
+      <div className="flex gap-8">
+        {Array.from(imgList).map((file, idx) => (
+          <div key={idx} className="relative flex h-120 w-120 shrink-0">
+            <button
+              onClick={() => setImgList((prev) => prev.filter((item) => item !== file))}
+              type="button"
+              className="absolute right-4 top-4 z-nav flex h-24 w-24 cursor-pointer items-center justify-center rounded-full bg-gray-900 bg-opacity-65"
+            >
+              <CloseIcon width="20" height="20" stroke="#FFFFFF" />
+            </button>
+            {idx === 0 && <span className="absolute left-4 top-4 z-nav rounded-[0.8rem] bg-[#000000]/[.72] px-8 py-4 text-12 text-white-white">대표이미지</span>}
+            <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 이미지 미리보기" fill className="object-cover" />
+          </div>
+        ))}
       </div>
-      {imgList.length <= 5 ? (
-        <div className="text-12 font-500 text-gray-300">첫번째 이미지가 썸네일로 등록됩니다.</div>
-      ) : (
-        <div className="text-12 font-500 text-red">이미지는 최대 5개까지 업로드 가능합니다.</div>
-      )}
     </div>
   );
 };
 
-export default ImageSection;
+export const MemoizedImageSection = React.memo(ImageSection);

--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import { Dispatch, SetStateAction } from "react";
 import InputFile from "@/components/input/InputFile";
-import LeftIcon from "@/public/icon/arrow-left_sm.svg";
 import CloseIcon from "@/public/icon/close.svg";
 
 interface Props {

--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import { Dispatch, SetStateAction } from "react";
 import InputFile from "@/components/input/InputFile";
+import LeftIcon from "@/public/icon/arrow-left_sm.svg";
 import CloseIcon from "@/public/icon/close.svg";
 
 interface Props {
@@ -12,16 +13,20 @@ const ImageSection = ({ imgList, setImgList }: Props) => {
   return (
     <div className="flex flex-col gap-8">
       <div>이미지</div>
-      <div className="flex gap-8">
+      <div className="flex gap-8 overflow-x-scroll scrollbar-hide">
         {imgList.length < 5 && <InputFile name="eventImages" />}
-        <div className="flex w-[400px] gap-8 overflow-x-scroll scrollbar-hide">
+        <div className="flex gap-8">
           {Array.from(imgList).map((file, idx) => (
-            <div key={idx} className="relative flex h-120 w-120 shrink-0" onClick={() => setImgList((prev) => prev.filter((item) => item !== file))}>
-              <button className="absolute right-4 top-4 z-nav cursor-pointer">
-                <CloseIcon width="24" height="24" stroke="#FFFFFF" />
+            <div key={idx} className="relative flex h-120 w-120 shrink-0">
+              <button
+                onClick={() => setImgList((prev) => prev.filter((item) => item !== file))}
+                type="button"
+                className="absolute right-4 top-4 z-nav flex h-24 w-24 cursor-pointer items-center justify-center rounded-full bg-gray-900 bg-opacity-65"
+              >
+                <CloseIcon width="20" height="20" stroke="#FFFFFF" />
               </button>
               {idx === 0 && <span className="absolute left-4 top-4 z-nav rounded-[0.8rem] bg-[#000000]/[.72] px-8 py-4 text-12 text-white-white">대표이미지</span>}
-              <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 사진 미리보기" fill className="object-cover" />
+              <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 이미지 미리보기" fill className="object-cover" />
             </div>
           ))}
         </div>

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -43,6 +43,7 @@ const DetailInput = () => {
         name="description"
         placeholder="이벤트 설명을 입력하세요."
         rules={{ maxLength: 100 }}
+        hasLimit
         isEdit={validateEdit(defaultValues?.description !== getValues("description"))}
       >
         상세 내용

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -4,7 +4,7 @@ import WarningCheck from "@/components/WarningCheck";
 import InputArea from "@/components/input/InputArea";
 import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
-import ImageSection from "../ImageSection";
+import { MemoizedImageSection } from "../ImageSection";
 
 const DetailInput = () => {
   const {
@@ -30,11 +30,18 @@ const DetailInput = () => {
 
   return (
     <>
-      <ImageSection imgList={imgList} setImgList={setImgList} />
+      <section className="flex flex-col gap-8">
+        <div>이미지</div>
+        <MemoizedImageSection imgList={imgList} setImgList={setImgList} />
+        {imgList.length <= 5 ? (
+          <div className="text-12 font-500 text-gray-300">첫번째 이미지가 썸네일로 등록됩니다.</div>
+        ) : (
+          <div className="text-12 font-500 text-red">이미지는 최대 5개까지 업로드 가능합니다.</div>
+        )}
+      </section>
       <InputArea
         name="description"
         placeholder="이벤트 설명을 입력하세요."
-        hasLimit
         rules={{ maxLength: 100 }}
         isEdit={validateEdit(defaultValues?.description !== getValues("description"))}
       >

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -5,6 +5,7 @@ import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { useModal } from "@/hooks/useModal";
 import { validateEdit } from "@/utils/editValidate";
+import { handleEnterDown } from "@/utils/handleEnterDown";
 import { PostType } from "../../page";
 
 const MainInput = () => {
@@ -27,7 +28,7 @@ const MainInput = () => {
           name="address"
           placeholder="도로명주소 검색"
           readOnly
-          onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("address") : null)}
+          onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("address"))}
           onClick={() => openBottomSheet("address")}
           isEdit={validateEdit(defaultValues?.address !== address)}
         >
@@ -43,7 +44,7 @@ const MainInput = () => {
               name="startDate"
               placeholder="날짜 선택"
               readOnly
-              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("date") : null)}
+              onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("date"))}
               onClick={() => openBottomSheet("date")}
               isEdit={validateEdit(defaultValues?.startDate !== startDate)}
             />
@@ -54,7 +55,7 @@ const MainInput = () => {
               name="endDate"
               placeholder="날짜 선택"
               readOnly
-              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("date") : null)}
+              onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("date"))}
               onClick={() => openBottomSheet("date")}
               isEdit={validateEdit(defaultValues?.endDate !== endDate)}
             />

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -23,7 +23,14 @@ const MainInput = () => {
         장소 이름
       </InputText>
       <div className="flex flex-col">
-        <InputText name="address" placeholder="도로명주소 검색" readOnly onClick={() => openBottomSheet("address")} isEdit={validateEdit(defaultValues?.address !== address)}>
+        <InputText
+          name="address"
+          placeholder="도로명주소 검색"
+          readOnly
+          onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("address") : null)}
+          onClick={() => openBottomSheet("address")}
+          isEdit={validateEdit(defaultValues?.address !== address)}
+        >
           주소
         </InputText>
         <InputText name="addressDetail" placeholder="상세 주소 입력" isEdit={validateEdit(defaultValues?.addressDetail !== addressDetail)} />
@@ -32,11 +39,25 @@ const MainInput = () => {
         기간
         <div className="flex">
           <div className="w-1/2">
-            <InputText name="startDate" placeholder="날짜 선택" readOnly onClick={() => openBottomSheet("date")} isEdit={validateEdit(defaultValues?.startDate !== startDate)} />
+            <InputText
+              name="startDate"
+              placeholder="날짜 선택"
+              readOnly
+              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("date") : null)}
+              onClick={() => openBottomSheet("date")}
+              isEdit={validateEdit(defaultValues?.startDate !== startDate)}
+            />
           </div>
           <div className="flex items-center px-4">~</div>
           <div className="w-1/2">
-            <InputText name="endDate" placeholder="날짜 선택" readOnly onClick={() => openBottomSheet("date")} isEdit={validateEdit(defaultValues?.endDate !== endDate)} />
+            <InputText
+              name="endDate"
+              placeholder="날짜 선택"
+              readOnly
+              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("date") : null)}
+              onClick={() => openBottomSheet("date")}
+              isEdit={validateEdit(defaultValues?.endDate !== endDate)}
+            />
           </div>
         </div>
       </div>

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -4,6 +4,7 @@ import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
 import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import { validateEdit } from "@/utils/editValidate";
+import { handleEnterDown } from "@/utils/handleEnterDown";
 import { PostType } from "../../page";
 
 const StarInput = () => {
@@ -26,15 +27,15 @@ const StarInput = () => {
               name="groupName"
               placeholder="아티스트 선택"
               readOnly
-              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("firstArtist") : null)}
               onClick={() => openBottomSheet("firstArtist")}
+              onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("firstArtist"))}
             />
             <InputText
               name="artistNames"
               placeholder="멤버 선택"
               readOnly
-              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("secondArtist") : null)}
               onClick={() => openBottomSheet("secondArtist")}
+              onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("secondArtist"))}
             />
           </div>
           {isNotMember && <div className="pt-4 text-12 font-500 text-red">그룹 선택 시, 멤버 선택이 필수입니다.</div>}
@@ -43,8 +44,9 @@ const StarInput = () => {
           name="eventType"
           readOnly
           placeholder="행사 유형을 선택하세요."
+          tabIndex={0}
           onClick={() => openBottomSheet("event")}
-          onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("event") : null)}
+          onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("event"))}
           isEdit={validateEdit(defaultValues?.eventType !== eventType)}
         >
           행사 유형

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -22,8 +22,20 @@ const StarInput = () => {
         <div className="flex flex-col">
           아티스트
           <div className="grid grid-cols-2 gap-8">
-            <InputText name="groupName" placeholder="아티스트 선택" readOnly onClick={() => openBottomSheet("firstArtist")} />
-            <InputText name="artistNames" placeholder="멤버 선택" readOnly onClick={() => openBottomSheet("secondArtist")} />
+            <InputText
+              name="groupName"
+              placeholder="아티스트 선택"
+              readOnly
+              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("firstArtist") : null)}
+              onClick={() => openBottomSheet("firstArtist")}
+            />
+            <InputText
+              name="artistNames"
+              placeholder="멤버 선택"
+              readOnly
+              onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("secondArtist") : null)}
+              onClick={() => openBottomSheet("secondArtist")}
+            />
           </div>
           {isNotMember && <div className="pt-4 text-12 font-500 text-red">그룹 선택 시, 멤버 선택이 필수입니다.</div>}
         </div>
@@ -32,6 +44,7 @@ const StarInput = () => {
           readOnly
           placeholder="행사 유형을 선택하세요."
           onClick={() => openBottomSheet("event")}
+          onKeyDown={(event) => (event.key === "Enter" ? openBottomSheet("event") : null)}
           isEdit={validateEdit(defaultValues?.eventType !== eventType)}
         >
           행사 유형

--- a/app/(route)/post/page.tsx
+++ b/app/(route)/post/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import GenericFormProvider from "@/components/GenericFormProvider";
 import Header from "@/components/Header";
 import { useFunnel } from "@/hooks/useFunnel";
 import { PostStepNameType } from "@/types/index";
-import BackIcon from "@/public/icon/arrow-left_lg.svg";
 import DetailInfo from "./_components/DetailInfo";
 import MainInfo from "./_components/MainInfo";
 import StarInfo from "./_components/StarInfo";

--- a/app/(route)/signup/page.tsx
+++ b/app/(route)/signup/page.tsx
@@ -19,8 +19,6 @@ const DEFAULT_VALUES = {
 };
 
 const SignUp = () => {
-  const searchParams = useSearchParams();
-  const defaultEmail = searchParams.get("email");
   const router = useRouter();
   const { Funnel, Step, setStep, currentStep } = useFunnel(STEPS);
 
@@ -38,7 +36,7 @@ const SignUp = () => {
   return (
     <>
       <Header onClick={handlePrevClick} />
-      <GenericFormProvider<SignUpFormType> formOptions={{ mode: "onBlur", defaultValues: { ...DEFAULT_VALUES, email: defaultEmail ?? "" } }}>
+      <GenericFormProvider<SignUpFormType> formOptions={{ mode: "onBlur", defaultValues: DEFAULT_VALUES }}>
         <div className="flex flex-col px-20">
           <ProfileSetup steps={STEPS} handleNextClick={handleNextClick} Funnel={Funnel} Step={Step} />
         </div>

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -1,5 +1,5 @@
 import { Api } from "app/_api/api";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
 import { handlePostSubmit } from "@/utils/submitPost";
@@ -12,12 +12,14 @@ interface GenericFormProps<T extends FieldValues> {
 const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: GenericFormProps<T>) => {
   const methods = useForm<T>(formOptions);
   const path = usePathname();
+  const router = useRouter();
   const instance = new Api(process.env.NEXT_PUBLIC_ACCESS_TOKEN);
 
   const onSubmit = async () => {
     console.log(methods.getValues()); // 회원가입 POST할 정보
     if (path === "/post") {
-      handlePostSubmit(methods.getValues(), instance);
+      const res = await handlePostSubmit(methods.getValues(), instance);
+      router.push(`/event/${res.eventId}`);
     }
   };
 

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -2,8 +2,7 @@ import { Api } from "app/_api/api";
 import { usePathname } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
-import { GiftType } from "@/types/index";
-import { TAG } from "@/constants/data";
+import { handlePostSubmit } from "@/utils/submitPost";
 
 interface GenericFormProps<T extends FieldValues> {
   children: React.ReactNode;
@@ -15,64 +14,10 @@ const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: G
   const path = usePathname();
   const instance = new Api(process.env.NEXT_PUBLIC_ACCESS_TOKEN);
 
-  const uploadImg = async (image: File) => {
-    const formData = new FormData();
-    formData.append("file", image);
-    const res = await instance.post("/file/upload", formData, { category: "event" });
-    return res;
-  };
-
-  const matchTagIdList = (tags: GiftType[]) => {
-    let tagList: string[] = [];
-    tags.map((goods: GiftType) => {
-      tagList.push(TAG[goods]);
-    });
-    return tagList;
-  };
-
-  const makeImgUrlList = async (eventImages: (string | File)[]) => {
-    let imageUrlList: string[] = [];
-    for (const image of eventImages) {
-      if (typeof image !== "string") {
-        const res = await uploadImg(image);
-        imageUrlList.push(res);
-      } else {
-        imageUrlList.push(image);
-      }
-    }
-
-    return imageUrlList;
-  };
-
-  const handlePostSubmit = async () => {
-    const userInput = methods.getValues();
-    const { placeName, eventType, groupId, artists, startDate, endDate, address, addressDetail, eventImages, description, eventUrl, organizerSns, snsType, tags } = userInput;
-    const imgUrlList = await makeImgUrlList(eventImages);
-    const tagList = matchTagIdList(tags);
-    const response = await instance.post("/event", {
-      placeName,
-      eventType,
-      groupId,
-      artists,
-      startDate,
-      endDate,
-      address,
-      addressDetail,
-      description,
-      eventUrl,
-      organizerSns,
-      snsType,
-      eventImages: imgUrlList,
-      tags: tagList,
-      isAgreed: true,
-      userId: "post-api",
-    });
-  };
-
   const onSubmit = async () => {
     console.log(methods.getValues()); // 회원가입 POST할 정보
     if (path === "/post") {
-      handlePostSubmit();
+      handlePostSubmit(methods.getValues(), instance);
     }
   };
 

--- a/app/_components/bottom-sheet/StarBottomSheet.tsx
+++ b/app/_components/bottom-sheet/StarBottomSheet.tsx
@@ -97,15 +97,25 @@ const StarBottomSheet = ({ closeBottomSheet, refs, isFirst = false }: Props) => 
         ) : (
           <>
             <SearchInput setKeyword={setKeyword} />
-            <div className="grid h-[34rem] grid-cols-3 overflow-y-scroll scrollbar-thin scrollbar-thumb-gray-100 scrollbar-track-rounded-full scrollbar-thumb-rounded-full">
-              {isLoading && <div>데이터 로딩중 ~~</div>}
-              {isSuccess &&
-                groupData.groupAndSoloList.map(({ id, image, name, type }: any) => (
-                  <ArtistCard key={id} profileImage={image}>
-                    {name}
-                  </ArtistCard>
-                ))}
-            </div>
+            {isLoading && <div>데이터 로딩중 ~~</div>}
+            {isSuccess && (
+              <ArtistList
+                render={() => (
+                  <>
+                    {groupData.groupAndSoloList.map(({ id, image, name, type }: any) => (
+                      <ArtistCard
+                        key={id}
+                        profileImage={image}
+                        isChecked={getValues("groupId") === id || getValues("artists").includes(id)}
+                        onClick={() => handleFirstDepthClick(type, id, name)}
+                      >
+                        {name}
+                      </ArtistCard>
+                    ))}
+                  </>
+                )}
+              />
+            )}
           </>
         )}
       </div>

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -81,9 +81,13 @@ const InputText: Function = ({
 
   const ErrorField = useCallback(() => {
     return (
-      <div className="mt-4 flex h-12">
-        {(!!fieldState.error || hint) && <p className={`font-normal text-12 ${fieldState.error ? "text-red" : "text-gray-500"}`}>{fieldState?.error?.message || hint}</p>}
-      </div>
+      <>
+        {(!!fieldState.error || hint) && (
+          <div className="mt-4 flex h-12">
+            <p className={`font-normal text-12 ${fieldState.error ? "text-red" : "text-gray-500"}`}>{fieldState?.error?.message || hint}</p>
+          </div>
+        )}
+      </>
     );
   }, [fieldState.error]);
 

--- a/app/_hooks/useFetchMember.ts
+++ b/app/_hooks/useFetchMember.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
+import { Api } from "app/_api/api";
 import { useEffect, useState } from "react";
-import { Api } from "@/api/api";
 
 export const useFetchMember = (instance: Api, getValues: (name: string) => string, isFirst: boolean) => {
   const [groupId, setGroupId] = useState(getValues("groupId"));

--- a/app/_utils/changeImgUrl.ts
+++ b/app/_utils/changeImgUrl.ts
@@ -1,0 +1,25 @@
+import { Api } from "@/api/api";
+
+export const uploadImg = async (image: File, instance: Api) => {
+  const formData = new FormData();
+  formData.append("file", image);
+  const res = await instance.post("/file/upload", formData, { category: "event" });
+  return res;
+};
+
+/**
+ * File 형식의 이미지 리스트를 url 형식의 이미지 리스트로 바꿔주는 함수
+ */
+export const makeImgUrlList = async (eventImages: (string | File)[], instance: Api) => {
+  let imageUrlList: string[] = [];
+  for (const image of eventImages) {
+    if (typeof image !== "string") {
+      const res = await uploadImg(image, instance);
+      imageUrlList.push(res);
+    } else {
+      imageUrlList.push(image);
+    }
+  }
+
+  return imageUrlList;
+};

--- a/app/_utils/changeImgUrl.ts
+++ b/app/_utils/changeImgUrl.ts
@@ -1,4 +1,4 @@
-import { Api } from "@/api/api";
+import { Api } from "app/_api/api";
 
 export const uploadImg = async (image: File, instance: Api) => {
   const formData = new FormData();

--- a/app/_utils/handleEnterDown.ts
+++ b/app/_utils/handleEnterDown.ts
@@ -1,0 +1,8 @@
+import { KeyboardEvent } from "react";
+
+export const handleEnterDown = (event: KeyboardEvent, openFunc: () => void) => {
+  if (event.key === "Enter") {
+    event.preventDefault();
+    openFunc();
+  }
+};

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -15,7 +15,7 @@ export const handlePostSubmit = async (userInput: any, instance: Api) => {
   const { placeName, eventType, groupId, artists, startDate, endDate, address, addressDetail, eventImages, description, eventUrl, organizerSns, snsType, tags } = userInput;
   const imgUrlList = await makeImgUrlList(eventImages, instance);
   const tagList = matchTagIdList(tags);
-  const response = await instance.post("/event", {
+  return await instance.post("/event", {
     placeName,
     eventType,
     groupId,

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -1,0 +1,36 @@
+import { Api } from "@/api/api";
+import { GiftType } from "@/types/index";
+import { TAG } from "@/constants/data";
+import { makeImgUrlList } from "./changeImgUrl";
+
+const matchTagIdList = (tags: GiftType[]) => {
+  let tagList: string[] = [];
+  tags.map((goods: GiftType) => {
+    tagList.push(TAG[goods]);
+  });
+  return tagList;
+};
+
+export const handlePostSubmit = async (userInput: any, instance: Api) => {
+  const { placeName, eventType, groupId, artists, startDate, endDate, address, addressDetail, eventImages, description, eventUrl, organizerSns, snsType, tags } = userInput;
+  const imgUrlList = await makeImgUrlList(eventImages, instance);
+  const tagList = matchTagIdList(tags);
+  const response = await instance.post("/event", {
+    placeName,
+    eventType,
+    groupId,
+    artists,
+    startDate,
+    endDate,
+    address,
+    addressDetail,
+    description,
+    eventUrl,
+    organizerSns,
+    snsType,
+    eventImages: imgUrlList,
+    tags: tagList,
+    isAgreed: true,
+    userId: "post-api",
+  });
+};

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -1,4 +1,4 @@
-import { Api } from "@/api/api";
+import { Api } from "app/_api/api";
 import { GiftType } from "@/types/index";
 import { TAG } from "@/constants/data";
 import { makeImgUrlList } from "./changeImgUrl";


### PR DESCRIPTION
## ✏️ 변경사항
### 🐛 Bug
- [x]  상세 내용을 입력할때마다 이미지 부분 렌더링이 계속 일어나는 것 같다. 이 문제를 해결했다!
→ 상세 내용 한 글자 입력할때마다 재렌더링 일어남

### ✨ Feat
- [x]  함수 util로 정리
- [x]  post 후 id 페이지로 이동 로직 추가
- [x]  바텀시트에 엔터 이벤트 추가 (기존에는 클릭해야만 됐었음)

### 💄 Design
- [x]  삭제 아이콘 변경
- [x]  이미지 전체 영역 스크롤로 변경

## 📷 스크린샷
![post-수정](https://github.com/P1Z7/frontend/assets/103186362/29ea6dff-b997-49b1-aee3-118d10474499)

## ✍️ 사용법

## 🎸 기타
