### PR TITLE
✨ feat: 수정 & 수정 신청 api 연결 완료

### DIFF
--- a/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
@@ -3,14 +3,12 @@ import MainInput from "@/(route)/post/_components/_inputs/MainInput";
 import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
-import classNames from "classnames";
 import { useFormContext } from "react-hook-form";
-import Alert from "@/components/Alert";
 import BottomButton from "@/components/button/BottomButton";
 import AlertModal from "@/components/modal/AlertModal";
-import TextModal from "@/components/modal/TextModal";
 import { useModal } from "@/hooks/useModal";
 import { useStore } from "@/store/index";
+import { checkArrUpdate } from "@/utils/checkArrUpdate";
 
 type PostValueType =
   | "placeName"
@@ -34,7 +32,6 @@ type PostValueType =
 const EditContent = () => {
   const { modal, openModal, closeModal } = useModal();
   const {
-    control,
     watch,
     formState: { defaultValues },
   } = useFormContext<PostType>();
@@ -51,13 +48,14 @@ const EditContent = () => {
       if (postTypeGuard(defaultValues, key)) {
         const prev = defaultValues[key];
         const cur = watchedValue[key];
+        if (typeof prev === "undefined" || typeof cur === "undefined") return false;
         switch (key) {
           case "artists":
           case "artistNames":
           case "tags":
           case "eventImages":
-            if (typeof prev === "string") return false;
-            isUpdated = cur.length !== prev?.length || !prev?.every((c, i) => c === cur[i]);
+            if (typeof prev === "string" || typeof cur === "string") return false;
+            isUpdated = checkArrUpdate(prev, cur);
             break;
           default:
             isUpdated = prev !== cur;

--- a/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
@@ -31,14 +31,11 @@ type PostValueType =
   | "tags";
 
 const EditContent = () => {
-  const { modal, openModal, closeModal } = useModal();
   const {
     watch,
     formState: { defaultValues },
   } = useFormContext<PostType>();
   const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
-  const { id } = useParams();
-  const router = useRouter();
   const watchedValue = watch();
 
   const checkUpdated = () => {
@@ -78,15 +75,7 @@ const EditContent = () => {
       <MainInput />
       <SubInput />
       <DetailInput />
-      <BottomButton isDisabled={!isValid} onClick={() => openModal("endEdit")}>
-        수정사항 등록
-      </BottomButton>
-      {modal === "endEdit" && (
-        <AlertModal closeModal={closeModal} handleBtnClick={() => router.push(`/event/${id}`)}>
-          수정사항은 사용자 3인 이상의
-          <br /> 승인 후에 반영됩니다.
-        </AlertModal>
-      )}
+      <BottomButton isDisabled={!isValid}>수정사항 등록</BottomButton>
     </div>
   );
 };

--- a/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
@@ -3,6 +3,7 @@ import MainInput from "@/(route)/post/_components/_inputs/MainInput";
 import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
+import { useParams, useRouter } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import BottomButton from "@/components/button/BottomButton";
 import AlertModal from "@/components/modal/AlertModal";
@@ -36,7 +37,8 @@ const EditContent = () => {
     formState: { defaultValues },
   } = useFormContext<PostType>();
   const { isCheck } = useStore((state) => ({ isCheck: state.isWarningCheck }));
-
+  const { id } = useParams();
+  const router = useRouter();
   const watchedValue = watch();
 
   const checkUpdated = () => {
@@ -80,7 +82,7 @@ const EditContent = () => {
         수정사항 등록
       </BottomButton>
       {modal === "endEdit" && (
-        <AlertModal closeModal={closeModal}>
+        <AlertModal closeModal={closeModal} handleBtnClick={() => router.push(`/event/${id}`)}>
           수정사항은 사용자 3인 이상의
           <br /> 승인 후에 반영됩니다.
         </AlertModal>

--- a/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
@@ -47,7 +47,9 @@ const EditContent = () => {
       if (postTypeGuard(defaultValues, key)) {
         const prev = defaultValues[key];
         const cur = watchedValue[key];
-        if (typeof prev === "undefined" || typeof cur === "undefined") return false;
+        if (typeof prev === "undefined" || typeof cur === "undefined") {
+          return false;
+        }
         switch (key) {
           case "artists":
           case "artistNames":

--- a/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/_components/EditContent.tsx
@@ -3,32 +3,11 @@ import MainInput from "@/(route)/post/_components/_inputs/MainInput";
 import StarInput from "@/(route)/post/_components/_inputs/StarInput";
 import SubInput from "@/(route)/post/_components/_inputs/SubInput";
 import { PostType } from "@/(route)/post/page";
-import { useParams, useRouter } from "next/navigation";
 import { useFormContext } from "react-hook-form";
 import BottomButton from "@/components/button/BottomButton";
-import AlertModal from "@/components/modal/AlertModal";
-import { useModal } from "@/hooks/useModal";
 import { useStore } from "@/store/index";
 import { checkArrUpdate } from "@/utils/checkArrUpdate";
-
-type PostValueType =
-  | "placeName"
-  | "eventType"
-  | "groupId"
-  | "artists"
-  | "groupName"
-  | "artistNames"
-  | "startDate"
-  | "endDate"
-  | "address"
-  | "addressDetail"
-  | "userId"
-  | "eventImages"
-  | "description"
-  | "eventUrl"
-  | "organizerSns"
-  | "snsType"
-  | "tags";
+import { PostValueType } from "@/types/index";
 
 const EditContent = () => {
   const {

--- a/app/(route)/(header)/event/[eventId]/edit/page.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/page.tsx
@@ -7,6 +7,7 @@ import { format } from "date-fns";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import GenericFormProvider from "@/components/GenericFormProvider";
+import { useStore } from "@/store/index";
 import EditContent from "./_components/EditContent";
 
 let INITIAL_DATA: PostType;
@@ -20,7 +21,7 @@ const Edit = () => {
       return instance.get(`/event/${eventId}`);
     },
   });
-  const [loading, setLoading] = useState(false);
+  const [isInit, setIsInit] = useState(false);
 
   useEffect(() => {
     if (isSuccess) {
@@ -48,13 +49,17 @@ const Edit = () => {
         snsType,
         tags,
       } as PostType;
-      setLoading(true);
+      setIsInit(true);
     }
   }, [data]);
 
+  useEffect(() => {
+    setIsInit(false);
+  }, []);
+
   return (
     <div className="flex flex-col gap-24 p-20 text-16">
-      {loading && (
+      {isInit && (
         <GenericFormProvider formOptions={{ mode: "onBlur", defaultValues: INITIAL_DATA, shouldFocusError: true }}>
           <EditContent />
         </GenericFormProvider>

--- a/app/(route)/(header)/event/[eventId]/edit/page.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/page.tsx
@@ -13,11 +13,11 @@ let INITIAL_DATA: PostType;
 
 const Edit = () => {
   const instance = new Api();
-  const { id } = useParams();
+  const { eventId } = useParams();
   const { data, isSuccess } = useQuery({
-    queryKey: ["event"],
+    queryKey: ["event", eventId],
     queryFn: async () => {
-      return instance.get(`/event/${id}`);
+      return instance.get(`/event/${eventId}`);
     },
   });
   const [loading, setLoading] = useState(false);

--- a/app/(route)/(header)/event/[eventId]/edit/page.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { PostType } from "@/(route)/post/page";
-import { useQuery } from "@tanstack/react-query";
 import { Api } from "app/_api/api";
 import { format } from "date-fns";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import GenericFormProvider from "@/components/GenericFormProvider";
-import { useStore } from "@/store/index";
 import EditContent from "./_components/EditContent";
 
 let INITIAL_DATA: PostType;
@@ -15,16 +13,11 @@ let INITIAL_DATA: PostType;
 const Edit = () => {
   const instance = new Api();
   const { eventId } = useParams();
-  const { data, isSuccess } = useQuery({
-    queryKey: ["event", eventId],
-    queryFn: async () => {
-      return instance.get(`/event/${eventId}`);
-    },
-  });
-  const [isInit, setIsInit] = useState(false);
+  const [init, setInit] = useState(false);
 
   useEffect(() => {
-    if (isSuccess) {
+    const fetchData = async () => {
+      const data = await instance.get(`/event/${eventId}`);
       const { address, addressDetail, description, endDate, startDate, eventImages, eventTags, eventUrl, eventType, organizerSns, placeName, snsType, targetArtists } = data;
       const artistNames: string[] = targetArtists.map(({ artistName }: { artistName: string }) => artistName);
       const artists = targetArtists.map(({ artistId }: { artistId: string }) => artistId);
@@ -49,17 +42,14 @@ const Edit = () => {
         snsType,
         tags,
       } as PostType;
-      setIsInit(true);
-    }
-  }, [data]);
-
-  useEffect(() => {
-    setIsInit(false);
+      setInit(true);
+    };
+    fetchData();
   }, []);
 
   return (
     <div className="flex flex-col gap-24 p-20 text-16">
-      {isInit && (
+      {init && (
         <GenericFormProvider formOptions={{ mode: "onBlur", defaultValues: INITIAL_DATA, shouldFocusError: true }}>
           <EditContent />
         </GenericFormProvider>

--- a/app/(route)/(header)/event/[eventId]/edit/page.tsx
+++ b/app/(route)/(header)/event/[eventId]/edit/page.tsx
@@ -1,40 +1,64 @@
 "use client";
 
+import { PostType } from "@/(route)/post/page";
+import { useQuery } from "@tanstack/react-query";
+import { Api } from "app/_api/api";
+import { format } from "date-fns";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import GenericFormProvider from "@/components/GenericFormProvider";
 import EditContent from "./_components/EditContent";
 
-const EDIT_MOCKUP_DATA = {
-  placeName: "홍대 멜로우",
-  eventType: "카페",
-  groupId: "",
-  artists: [],
-  groupName: "에스파",
-  artistNames: ["카리나"],
-  startDate: "2023-04-08",
-  endDate: "2023-04-11",
-  address: "서울 마포구 잔다리로 30-11",
-  addressDetail: "1층 멜로우",
-  eventImages: [
-    "https://fandomship.com/data/file/aespa/96d7bf5b058cf52803e681345d7f7847_z8rFhK5X_93129e63980a8f3c265ee5ab64387657ef7deec3.jpg",
-    "https://fandomship.com/data/file/aespa/96d7bf5b058cf52803e681345d7f7847_1VnrpEKF_f6ffd26dbdea69f0b3b60fecc99366c4c27c542c.jpg",
-  ],
-  description: "이거 실제 포스터보고 만든거임",
-  eventUrl: "https://fandomship.com/bbs/board.php?bo_table=aespa&wr_id=26",
-  organizerSns: "@HBD_KARINA_2023",
-  snsType: "트위터",
-  tags: ["굿즈", "포토카드", "컵홀더", "엽서", "스티커", "기타"],
-} as const;
-
-export type EditPostType = typeof EDIT_MOCKUP_DATA;
+let INITIAL_DATA: PostType;
 
 const Edit = () => {
-  //여기서 get하고 이미지들 file 형식으로 변환해서 default 값 설정..?
+  const instance = new Api();
+  const { id } = useParams();
+  const { data, isSuccess } = useQuery({
+    queryKey: ["event"],
+    queryFn: async () => {
+      return instance.get(`/event/${id}`);
+    },
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isSuccess) {
+      const { address, addressDetail, description, endDate, startDate, eventImages, eventTags, eventUrl, eventType, organizerSns, placeName, snsType, targetArtists } = data;
+      const artistNames: string[] = targetArtists.map(({ artistName }: { artistName: string }) => artistName);
+      const artists = targetArtists.map(({ artistId }: { artistId: string }) => artistId);
+      const tags = eventTags.map(({ tagName }: { tagName: string }) => tagName);
+      const imgList = eventImages.map(({ imageUrl }: { imageUrl: string }) => imageUrl);
+
+      INITIAL_DATA = {
+        placeName,
+        eventType,
+        groupId: targetArtists[0].groupId,
+        groupName: targetArtists[0].groupName,
+        artists,
+        artistNames,
+        startDate: format(startDate, "yyyy.MM.dd"),
+        endDate: format(endDate, "yyyy.MM.dd"),
+        address,
+        addressDetail,
+        eventImages: imgList,
+        description,
+        eventUrl,
+        organizerSns,
+        snsType,
+        tags,
+      } as PostType;
+      setLoading(true);
+    }
+  }, [data]);
 
   return (
     <div className="flex flex-col gap-24 p-20 text-16">
-      <GenericFormProvider formOptions={{ mode: "onBlur", defaultValues: EDIT_MOCKUP_DATA, shouldFocusError: true }}>
-        <EditContent />
-      </GenericFormProvider>
+      {loading && (
+        <GenericFormProvider formOptions={{ mode: "onBlur", defaultValues: INITIAL_DATA, shouldFocusError: true }}>
+          <EditContent />
+        </GenericFormProvider>
+      )}
     </div>
   );
 };

--- a/app/(route)/(header)/event/[eventId]/page.tsx
+++ b/app/(route)/(header)/event/[eventId]/page.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const getEventInfo = async (eventId: string) => {
-  const data = await fetch(`http://${process.env.NEXT_PUBLIC_BASE_URL}/event/${eventId}`);
+  const data = await fetch(`http://${process.env.NEXT_PUBLIC_BASE_URL}/event/${eventId}`, { cache: "no-store" });
   const res: Res_Get_Type["event"] = await data.json();
   return res;
 };

--- a/app/(route)/post/_components/ImageSection.tsx
+++ b/app/(route)/post/_components/ImageSection.tsx
@@ -23,7 +23,7 @@ const ImageSection = ({ imgList, setImgList }: Props) => {
               <CloseIcon width="20" height="20" stroke="#FFFFFF" />
             </button>
             {idx === 0 && <span className="absolute left-4 top-4 z-nav rounded-[0.8rem] bg-[#000000]/[.72] px-8 py-4 text-12 text-white-white">대표이미지</span>}
-            <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 이미지 미리보기" fill className="object-cover" />
+            <Image src={typeof file === "string" ? file : URL.createObjectURL(file)} alt="선택한 이미지 미리보기" fill sizes="120, 120" className="object-cover" />
           </div>
         ))}
       </div>

--- a/app/(route)/post/_components/_inputs/DetailInput.tsx
+++ b/app/(route)/post/_components/_inputs/DetailInput.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import WarningCheck from "@/components/WarningCheck";
 import InputArea from "@/components/input/InputArea";
+import { checkArrUpdate } from "@/utils/checkArrUpdate";
 import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
 import { MemoizedImageSection } from "../ImageSection";
@@ -31,7 +32,12 @@ const DetailInput = () => {
   return (
     <>
       <section className="flex flex-col gap-8">
-        <div>이미지</div>
+        <div className="flex items-center gap-4">
+          이미지
+          {validateEdit(typeof defaultValues?.eventImages !== "undefined" && checkArrUpdate(defaultValues?.eventImages, imgList)) && (
+            <p className="text-12 font-600 text-blue">수정됨</p>
+          )}
+        </div>
         <MemoizedImageSection imgList={imgList} setImgList={setImgList} />
         {imgList.length <= 5 ? (
           <div className="text-12 font-500 text-gray-300">첫번째 이미지가 썸네일로 등록됩니다.</div>

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -30,14 +30,17 @@ const MainInput = () => {
           readOnly
           onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("address"))}
           onClick={() => openBottomSheet("address")}
-          isEdit={validateEdit(defaultValues?.address !== address)}
+          isEdit={validateEdit(defaultValues?.address !== address || defaultValues?.addressDetail !== addressDetail)}
         >
           주소
         </InputText>
-        <InputText name="addressDetail" placeholder="상세 주소 입력" isEdit={validateEdit(defaultValues?.addressDetail !== addressDetail)} />
+        <InputText name="addressDetail" placeholder="상세 주소 입력" />
       </div>
       <div className="flex flex-col">
-        기간
+        <div className="flex items-center gap-4">
+          기간
+          {validateEdit(defaultValues?.startDate !== startDate || defaultValues?.endDate !== endDate) && <p className="text-12 font-600 text-blue">수정됨</p>}
+        </div>
         <div className="flex">
           <div className="w-1/2">
             <InputText
@@ -46,7 +49,6 @@ const MainInput = () => {
               readOnly
               onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("date"))}
               onClick={() => openBottomSheet("date")}
-              isEdit={validateEdit(defaultValues?.startDate !== startDate)}
             />
           </div>
           <div className="flex items-center px-4">~</div>
@@ -57,7 +59,6 @@ const MainInput = () => {
               readOnly
               onKeyDown={(event) => handleEnterDown(event, () => openBottomSheet("date"))}
               onClick={() => openBottomSheet("date")}
-              isEdit={validateEdit(defaultValues?.endDate !== endDate)}
             />
           </div>
         </div>

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -3,6 +3,7 @@ import EventTypeBottomSheet from "@/components/bottom-sheet/EventTypeBottomSheet
 import StarBottomSheet from "@/components/bottom-sheet/StarBottomSheet";
 import InputText from "@/components/input/InputText";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
+import { checkArrUpdate } from "@/utils/checkArrUpdate";
 import { validateEdit } from "@/utils/editValidate";
 import { handleEnterDown } from "@/utils/handleEnterDown";
 import { PostType } from "../../page";
@@ -14,14 +15,19 @@ const StarInput = () => {
     formState: { defaultValues },
     watch,
   } = useFormContext<PostType>();
-  const { eventType, groupName, groupId, artistNames, artists } = watch();
+  const { eventType, groupId, artistNames, artists } = watch();
   const isNotMember = groupId && artistNames.length === 0;
 
   return (
     <>
       <div className="flex-item flex flex-col gap-20">
         <div className="flex flex-col">
-          아티스트
+          <label className="flex items-center gap-4">
+            아티스트
+            {validateEdit(typeof defaultValues?.artists !== "undefined" && (checkArrUpdate(defaultValues?.artists, artists) || defaultValues?.groupId !== groupId)) && (
+              <p className="text-12 font-600 text-blue">수정됨</p>
+            )}
+          </label>
           <div className="grid grid-cols-2 gap-8">
             <InputText
               name="groupName"

--- a/app/(route)/post/_components/_inputs/SubInput.tsx
+++ b/app/(route)/post/_components/_inputs/SubInput.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import ChipButton from "@/components/chip/ChipButton";
 import InputText from "@/components/input/InputText";
+import { checkArrUpdate } from "@/utils/checkArrUpdate";
 import { validateEdit } from "@/utils/editValidate";
 import { PostType } from "../../page";
 
@@ -40,14 +41,18 @@ const SubInput = () => {
     <div>
       <div className="flex flex-col gap-20">
         <div className="flex flex-col gap-16">
-          <InputText name="organizerSns" placeholder="sns 계정을 입력해주세요." isEdit={validateEdit(defaultValues?.organizerSns !== organizerSns)}>
+          <InputText
+            name="organizerSns"
+            placeholder="sns 계정을 입력해주세요."
+            isEdit={validateEdit(defaultValues?.organizerSns !== organizerSns || defaultValues.snsType !== snsType)}
+          >
             주최자
           </InputText>
           <div className="flex gap-16">
             {SNS_TYPE_LIST.map((type) => (
               <label key={type} className="flex cursor-pointer items-center gap-4">
                 <input
-                  className="checked:border-main-pink-500 hover:bg-main-pink-50 h-16 w-16 cursor-pointer appearance-none rounded-full border-2 border-gray-200 checked:border-[0.5rem]"
+                  className="h-16 w-16 cursor-pointer appearance-none rounded-full border-2 border-gray-200 checked:border-[0.5rem] checked:border-main-pink-500 hover:bg-main-pink-50"
                   name="sns"
                   value={type}
                   type="radio"
@@ -63,7 +68,10 @@ const SubInput = () => {
           링크
         </InputText>
         <div className="flex flex-col gap-8">
-          특전
+          <div className="flex items-center gap-4">
+            특전
+            {validateEdit(typeof defaultValues?.tags !== "undefined" && checkArrUpdate(defaultValues?.tags, giftList)) && <p className="text-12 font-600 text-blue">수정됨</p>}
+          </div>
           <ul className="flex flex-wrap gap-8 gap-y-12">
             {GIFT_LIST.map((gift) => (
               <li key={gift}>

--- a/app/_api/api.ts
+++ b/app/_api/api.ts
@@ -1,6 +1,8 @@
 import { Req_Post_Type } from "@/types/postBodyType";
 import { Req_Query_Type } from "@/types/queryType";
 
+const STR_RES_ENDPOINT = ["/file/upload", "/event/update/application"];
+
 export class Api {
   private baseUrl;
   private queryString;
@@ -51,7 +53,7 @@ export class Api {
         Authorization: `Bearer ${this.accessToken}`,
       },
     });
-    return endPoint === "/file/upload" ? await res.text() : await res.json();
+    return STR_RES_ENDPOINT.includes(endPoint) ? await res.text() : await res.json();
   }
 
   async put<T extends PutEndPoint>(endPoint: T, body: PutBodyType<T>) {
@@ -81,7 +83,18 @@ export class Api {
 }
 
 type GetEndPoint = "/event" | "/event/like" | `/event/${string}` | "/artist/group" | `/artist/${string}` | "/group/solo" | `/reviews/${string}`;
-type PostEndPoint = "/event" | "/event/like" | "/users" | "/auth" | "/auth/token" | "/artist" | "/group" | "/file/upload" | "/reviews" | `/reviews/${string}/like`;
+type PostEndPoint =
+  | "/event"
+  | "/event/like"
+  | "/users"
+  | "/auth"
+  | "/auth/token"
+  | "/artist"
+  | "/group"
+  | "/file/upload"
+  | "/reviews"
+  | `/reviews/${string}/like`
+  | "/event/update/application";
 type PutEndPoint = `/event/${string}`;
 type DeleteEndPoint = `/users/${string}/artists` | `/reviews/${string}/images`;
 type PostQueryType<T> = T extends "/file/upload" ? { category: "event" | "artist" | "user" } : unknown;
@@ -106,7 +119,9 @@ type PostBodyType<T> = T extends "/event"
                   ? Req_Post_Type["review"]
                   : T extends `/reviews/${string}/like`
                     ? Req_Post_Type["reviewLike"]
-                    : unknown;
+                    : T extends "/event/update/application"
+                      ? Req_Post_Type["edit"]
+                      : unknown;
 
 type GetQueryType<T> = T extends "/event"
   ? Req_Query_Type["행사목록"]

--- a/app/_api/api.ts
+++ b/app/_api/api.ts
@@ -54,7 +54,7 @@ export class Api {
     return endPoint === "/file/upload" ? await res.text() : await res.json();
   }
 
-  async put<T>(endPoint: string, body: T) {
+  async put<T extends PutEndPoint>(endPoint: T, body: PutBodyType<T>) {
     this.baseUrl = "/api" + endPoint;
     const res = await fetch(this.baseUrl, {
       method: "PUT",
@@ -67,10 +67,11 @@ export class Api {
     return await res.json();
   }
 
-  async delete(endPoint: string) {
+  async delete<T extends DeleteEndPoint>(endPoint: T, body: DeleteBodyType<T>) {
     this.baseUrl = "/api" + endPoint;
     const res = await fetch(this.baseUrl, {
       method: "DELETE",
+      body: JSON.stringify(body),
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
       },
@@ -81,7 +82,8 @@ export class Api {
 
 type GetEndPoint = "/event" | "/event/like" | `/event/${string}` | "/artist/group" | `/artist/${string}` | "/group/solo" | `/reviews/${string}`;
 type PostEndPoint = "/event" | "/event/like" | "/users" | "/auth" | "/auth/token" | "/artist" | "/group" | "/file/upload" | "/reviews" | `/reviews/${string}/like`;
-
+type PutEndPoint = `/event/${string}`;
+type DeleteEndPoint = `/users/${string}/artists` | `/reviews/${string}/images`;
 type PostQueryType<T> = T extends "/file/upload" ? { category: "event" | "artist" | "user" } : unknown;
 
 type PostBodyType<T> = T extends "/event"
@@ -121,3 +123,6 @@ type GetQueryType<T> = T extends "/event"
             : T extends `/reviews/${string}`
               ? Req_Query_Type["리뷰"]
               : unknown;
+// 사용하실 때 직접 추가 부탁드립니다!
+type PutBodyType<T> = T extends `/event/${string}` ? Req_Post_Type["event"] : any;
+type DeleteBodyType<T> = any;

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -1,5 +1,5 @@
 import { Api } from "app/_api/api";
-import { usePathname, useRouter } from "next/navigation";
+import { useParams, usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
 import { handlePostSubmit } from "@/utils/submitPost";
@@ -12,6 +12,7 @@ interface GenericFormProps<T extends FieldValues> {
 const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: GenericFormProps<T>) => {
   const methods = useForm<T>(formOptions);
   const path = usePathname();
+  const { editId } = useParams();
   const router = useRouter();
   const instance = new Api(process.env.NEXT_PUBLIC_ACCESS_TOKEN);
 
@@ -20,6 +21,9 @@ const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: G
     if (path === "/post") {
       const res = await handlePostSubmit(methods.getValues(), instance);
       router.push(`/event/${res.eventId}`);
+    }
+    if (path === `/event/${editId}/edit`) {
+      console.log("수정하려구?");
     }
   };
 

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -2,7 +2,7 @@ import { Api } from "app/_api/api";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
-import { handlePostSubmit } from "@/utils/submitPost";
+import { handleEditSubmit, handlePostSubmit } from "@/utils/submitPost";
 
 interface GenericFormProps<T extends FieldValues> {
   children: React.ReactNode;
@@ -12,7 +12,7 @@ interface GenericFormProps<T extends FieldValues> {
 const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: GenericFormProps<T>) => {
   const methods = useForm<T>(formOptions);
   const path = usePathname();
-  const { editId } = useParams();
+  const { editId, id } = useParams();
   const router = useRouter();
   const instance = new Api(process.env.NEXT_PUBLIC_ACCESS_TOKEN);
 
@@ -22,7 +22,8 @@ const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: G
       const res = await handlePostSubmit(methods.getValues(), instance);
       router.push(`/event/${res.eventId}`);
     }
-    if (path === `/event/${editId}/edit`) {
+    if (path === `/event/${id}/edit`) {
+      const res = await handleEditSubmit(methods.getValues(), instance, id);
       console.log("수정하려구?");
     }
   };

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -3,7 +3,7 @@ import { useParams, usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
 import { useModal } from "@/hooks/useModal";
-import { handlePostSubmit, submitEditWriter } from "@/utils/submitPost";
+import { handlePostSubmit, submitEditApplication, submitEditWriter } from "@/utils/submitPost";
 import AlertModal from "./modal/AlertModal";
 
 interface GenericFormProps<T extends FieldValues> {
@@ -21,14 +21,17 @@ const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: G
 
   const onSubmit = async () => {
     console.log(methods.getValues()); // 회원가입 POST할 정보
+    const userInputValue = methods.getValues();
+    const defaultValue = methods.formState.defaultValues;
     if (path === "/post") {
-      const res = await handlePostSubmit(methods.getValues(), instance);
+      const res = await handlePostSubmit(userInputValue, instance);
       router.push(`/event/${res.eventId}`);
     }
     if (path === `/event/${eventId}/edit`) {
       //작성 유저
       const res = await submitEditWriter(methods.getValues(), instance, eventId);
-
+      //신청 유저
+      // await submitEditApplication(instance, defaultValue, userInputValue, eventId);
       openModal("endEdit");
     }
   };

--- a/app/_components/GenericFormProvider.tsx
+++ b/app/_components/GenericFormProvider.tsx
@@ -2,7 +2,9 @@ import { Api } from "app/_api/api";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import React from "react";
 import { FieldValues, FormProvider, UseFormProps, useForm } from "react-hook-form";
-import { handleEditSubmit, handlePostSubmit } from "@/utils/submitPost";
+import { useModal } from "@/hooks/useModal";
+import { handlePostSubmit, submitEditWriter } from "@/utils/submitPost";
+import AlertModal from "./modal/AlertModal";
 
 interface GenericFormProps<T extends FieldValues> {
   children: React.ReactNode;
@@ -12,8 +14,9 @@ interface GenericFormProps<T extends FieldValues> {
 const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: GenericFormProps<T>) => {
   const methods = useForm<T>(formOptions);
   const path = usePathname();
-  const { editId, id } = useParams();
+  const { editId, eventId } = useParams();
   const router = useRouter();
+  const { modal, openModal, closeModal } = useModal();
   const instance = new Api(process.env.NEXT_PUBLIC_ACCESS_TOKEN);
 
   const onSubmit = async () => {
@@ -22,15 +25,23 @@ const GenericFormProvider = <T extends FieldValues>({ children, formOptions }: G
       const res = await handlePostSubmit(methods.getValues(), instance);
       router.push(`/event/${res.eventId}`);
     }
-    if (path === `/event/${id}/edit`) {
-      const res = await handleEditSubmit(methods.getValues(), instance, id);
-      console.log("수정하려구?");
+    if (path === `/event/${eventId}/edit`) {
+      //작성 유저
+      const res = await submitEditWriter(methods.getValues(), instance, eventId);
+
+      openModal("endEdit");
     }
   };
 
   return (
     <FormProvider {...methods}>
       <form onSubmit={methods.handleSubmit(onSubmit)}>{children}</form>
+      {modal === "endEdit" && (
+        <AlertModal closeModal={closeModal} handleBtnClick={() => router.push(`/event/${eventId}`)}>
+          수정사항은 사용자 3인 이상의
+          <br /> 승인 후에 반영됩니다.
+        </AlertModal>
+      )}
     </FormProvider>
   );
 };

--- a/app/_components/input/InputText.tsx
+++ b/app/_components/input/InputText.tsx
@@ -54,7 +54,7 @@ const InputText: Function = ({
         <label htmlFor={field.name} className={`flex items-center text-16 ${horizontal && "mt-20"}`}>
           {children}
           {required && <span className="ml-4 text-sub-red">*</span>}
-          {isEdit && <span className="ml-4 text-12 font-600 text-sub-skyblue">수정됨</span>}
+          {isEdit && <span className="ml-4 text-12 font-600 text-blue">수정됨</span>}
         </label>
       );
     }
@@ -92,29 +92,33 @@ const InputText: Function = ({
   }, [fieldState.error]);
 
   return (
-    <div className={`w-full ${horizontal && "flex gap-28"}`}>
-      <Label />
-      <div className={`relative ${horizontal && "flex-1"}`}>
-        <input
-          id={field.name}
-          type={type}
-          placeholder={placeholder ?? "입력해주세요."}
-          autoComplete={autoComplete ?? "off"}
-          hidden={hidden ?? false}
-          readOnly={readOnly ?? false}
-          disabled={disabled ?? false}
-          onClick={onClick}
-          onKeyDown={onKeyDown}
-          {...field}
-          className={classNames(
-            "focus:border-1 mt-8 h-48 w-full rounded-sm bg-gray-50 px-16 py-12 pr-36 text-16 text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-1 focus:outline-blue",
-            { "outline outline-1 outline-red": fieldState.error },
-          )}
-        />
-        <Button />
-        <ErrorField />
-      </div>
-    </div>
+    <>
+      {!hidden && (
+        <div className={`w-full ${horizontal && "flex gap-28"}`}>
+          <Label />
+          <div className={`relative ${horizontal && "flex-1"}`}>
+            <input
+              id={field.name}
+              type={type}
+              placeholder={placeholder ?? "입력해주세요."}
+              autoComplete={autoComplete ?? "off"}
+              hidden={hidden ?? false}
+              readOnly={readOnly ?? false}
+              disabled={disabled ?? false}
+              onClick={onClick}
+              onKeyDown={onKeyDown}
+              {...field}
+              className={classNames(
+                "focus:border-1 mt-8 h-48 w-full rounded-sm bg-gray-50 px-16 py-12 pr-36 text-16 text-gray-900 placeholder:text-gray-400 focus:outline focus:outline-1 focus:outline-blue",
+                { "outline outline-1 outline-red": fieldState.error },
+              )}
+            />
+            <Button />
+            <ErrorField />
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -174,3 +174,23 @@ export interface EventReviewType {
   user: UserType;
   reviewImages: { url: string; createdAt: string }[];
 }
+
+export type PostValueType =
+  | "placeName"
+  | "eventType"
+  | "groupId"
+  | "artists"
+  | "groupName"
+  | "artistNames"
+  | "startDate"
+  | "endDate"
+  | "address"
+  | "addressDetail"
+  | "eventImages"
+  | "description"
+  | "eventUrl"
+  | "organizerSns"
+  | "snsType"
+  | "tags";
+
+export type CategoryType = "placeName" | "eventType" | "artist" | "address" | "period" | "tags" | "eventImages" | "organizer" | "eventUrl" | "description";

--- a/app/_types/postBodyType.ts
+++ b/app/_types/postBodyType.ts
@@ -1,3 +1,5 @@
+import { CategoryType } from ".";
+
 type Req_Post_Event = {
   placeName: string;
   eventType: "카페" | "팝업스토어";
@@ -73,6 +75,29 @@ type Req_Post_Review_Like = {
   isLike: boolean;
 };
 
+type Req_Post_Edit_Application = {
+  eventId: string;
+  updateCategory: CategoryType[];
+  userId: string;
+  placeName?: string;
+  eventType?: string;
+  groupId?: string;
+  artists?: string[];
+  startDate?: string;
+  endDate?: string;
+  address?: string;
+  addressDetail?: string;
+  eventImages?: string[];
+  description?: string;
+  eventUrl?: string;
+  organizerSns?: string;
+  snsType?: string;
+  tags?: string[];
+  isAgreed: boolean;
+  groupName?: string;
+  artistNames?: string;
+};
+
 export type Req_Post_Type = {
   event: Req_Post_Event;
   eventLike: Req_Post_Event_Like;
@@ -83,4 +108,5 @@ export type Req_Post_Type = {
   group: Req_Post_Group;
   review: Req_Post_Review;
   reviewLike: Req_Post_Review_Like;
+  edit: Req_Post_Edit_Application;
 };

--- a/app/_utils/checkArrUpdate.ts
+++ b/app/_utils/checkArrUpdate.ts
@@ -1,3 +1,4 @@
 export const checkArrUpdate = (prev: any[], cur: any[]) => {
-  return cur.length !== prev?.length || !prev?.every((item) => cur.includes(item));
+  const curArr = Array.from(cur);
+  return curArr.length !== prev?.length || !prev?.every((item) => curArr.includes(item));
 };

--- a/app/_utils/checkArrUpdate.ts
+++ b/app/_utils/checkArrUpdate.ts
@@ -1,0 +1,3 @@
+export const checkArrUpdate = (prev: any[], cur: any[]) => {
+  return cur.length !== prev?.length || !prev?.every((item) => cur.includes(item));
+};

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -35,8 +35,7 @@ export const handlePostSubmit = async (userInput: any, instance: Api) => {
   });
 };
 
-export const handleEditSubmit = async (userInput: any, instance: Api, id?: string | string[]) => {
-  //작성한 유저일 때
+export const submitEditWriter = async (userInput: any, instance: Api, id?: string | string[]) => {
   const { placeName, eventType, groupId, artists, startDate, endDate, address, addressDetail, eventImages, description, eventUrl, organizerSns, snsType, tags } = userInput;
   const imgUrlList = await makeImgUrlList(eventImages, instance);
   const tagList = matchTagIdList(tags);
@@ -59,3 +58,5 @@ export const handleEditSubmit = async (userInput: any, instance: Api, id?: strin
     userId: "post-api",
   });
 };
+
+export const submitEditApplication = async () => {};

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -34,3 +34,28 @@ export const handlePostSubmit = async (userInput: any, instance: Api) => {
     userId: "post-api",
   });
 };
+
+export const handleEditSubmit = async (userInput: any, instance: Api, id?: string | string[]) => {
+  //작성한 유저일 때
+  const { placeName, eventType, groupId, artists, startDate, endDate, address, addressDetail, eventImages, description, eventUrl, organizerSns, snsType, tags } = userInput;
+  const imgUrlList = await makeImgUrlList(eventImages, instance);
+  const tagList = matchTagIdList(tags);
+  return await instance.put(`/event/${id}`, {
+    placeName,
+    eventType,
+    groupId,
+    artists,
+    startDate,
+    endDate,
+    address,
+    addressDetail,
+    description,
+    eventUrl,
+    organizerSns,
+    snsType,
+    eventImages: imgUrlList,
+    tags: tagList,
+    isAgreed: true,
+    userId: "post-api",
+  });
+};

--- a/app/_utils/submitPost.ts
+++ b/app/_utils/submitPost.ts
@@ -1,7 +1,41 @@
 import { Api } from "app/_api/api";
-import { GiftType } from "@/types/index";
+import { CategoryType, GiftType, PostValueType } from "@/types/index";
+import { Req_Post_Type } from "@/types/postBodyType";
 import { TAG } from "@/constants/data";
 import { makeImgUrlList } from "./changeImgUrl";
+import { checkArrUpdate } from "./checkArrUpdate";
+
+const EDIT_CATEGORY = {
+  placeName: "placeName",
+  eventType: "eventType",
+  groupId: "artist",
+  artists: "artist",
+  address: "address",
+  addressDetail: "address",
+  startDate: "period",
+  endDate: "period",
+  tags: "tags",
+  eventImages: "eventImages",
+  organizerSns: "organizer",
+  snsType: "organizer",
+  eventUrl: "eventUrl",
+  description: "description",
+  groupName: "null",
+  artistNames: "null",
+};
+
+const EDIT_CATEGORY_VALUE = {
+  placeName: ["placeName"],
+  eventType: ["eventType"],
+  artist: ["groupId", "artists"],
+  address: ["address", "addressDetail"],
+  period: ["startDate", "endDate"],
+  tags: ["tags"],
+  eventImages: ["eventImages"],
+  organizer: ["organizerSns", "snsType"],
+  eventUrl: ["eventUrl"],
+  description: ["description"],
+};
 
 const matchTagIdList = (tags: GiftType[]) => {
   let tagList: string[] = [];
@@ -9,6 +43,54 @@ const matchTagIdList = (tags: GiftType[]) => {
     tagList.push(TAG[goods]);
   });
   return tagList;
+};
+
+const makeUpdateCategory = (defaultValue: any, userInputValue: any, eventId: string) => {
+  const updateCategory: CategoryType[] = [];
+  const approveBody = new Map();
+  for (const key of Object.keys(defaultValue || {})) {
+    if (!defaultValue) {
+      return {
+        eventId,
+        updateCategory,
+        userId: "edit-api",
+        isAgreed: true,
+      };
+    }
+    const cur = userInputValue[key];
+    const prev = defaultValue[key];
+    switch (key) {
+      case "artists":
+        if (checkArrUpdate(prev, cur)) {
+          updateCategory.push("artist");
+          EDIT_CATEGORY_VALUE["artist"].map((value) => approveBody.set(value, userInputValue[value]));
+        }
+        break;
+      case "tags":
+      case "eventImages":
+        if (checkArrUpdate(prev, cur)) {
+          updateCategory.push(key);
+          approveBody.set(key, cur);
+        }
+        break;
+      default:
+        const category = EDIT_CATEGORY[key as PostValueType];
+        if (prev !== cur && category !== "null") {
+          updateCategory.push(category as CategoryType);
+          EDIT_CATEGORY_VALUE[category as CategoryType].map((value) => approveBody.set(value, userInputValue[value]));
+        }
+    }
+  }
+  let body: Req_Post_Type["edit"] = {
+    eventId,
+    updateCategory,
+    userId: "edit-api",
+    isAgreed: true,
+  };
+  for (const [key, value] of approveBody.entries()) {
+    body[key as PostValueType] = value;
+  }
+  return body;
 };
 
 export const handlePostSubmit = async (userInput: any, instance: Api) => {
@@ -59,4 +141,13 @@ export const submitEditWriter = async (userInput: any, instance: Api, id?: strin
   });
 };
 
-export const submitEditApplication = async () => {};
+export const submitEditApplication = async (instance: Api, defaultValue: any, userInput: any, id?: string | string[]) => {
+  const body = makeUpdateCategory(defaultValue, userInput, id as string);
+  if ("eventImages" in body) {
+    body.eventImages = await makeImgUrlList(body.eventImages || [], instance);
+  }
+  if ("tags" in body) {
+    body.tags = await matchTagIdList(body.tags as GiftType[]);
+  }
+  return await instance.post("/event/update/application", body);
+};


### PR DESCRIPTION
## ✏️ 변경사항
- 수정 api와 수정 신청 api를 연결했습니다.
- 유저id에 따른 케이스 구분은 해당 로직이 머지되면 추가하겠습니다.
- 일단 확인하기에는 모두 수정이 편하실것같아서 수정 신청 api는 주석처리 해놓은 상태입니다! (되는거 스웨거로 진짜 확인함,,)

## 📷 스크린샷
![edit-api](https://github.com/P1Z7/frontend/assets/103186362/87f6973d-bd58-4303-ac4c-8263b6a547be)

## ✍️ 사용법
- 홈페이지 -> 카드 클릭 -> 상세 페이지 -> 케밥 클릭 -> 수정하기 -> 수정하고, 수정 완료 버튼 누르기

## 🎸 기타
- 지금 수정에 await을 걸어놨는데도 상세 페이지로 넘어가면 바로 반영이 안돼서ㅠㅠ 아무래도 제가 서버컴포넌트 공부를 덜 한 것 같습니다,,, 이 부분은 조금 더 연구해볼게요ㅠㅠ!!
- (홈페이지로 연결하면 홈페이지에서는 바로 반영되는걸 봐서는... 디비가 바뀐걸 인식을 못하나봐요....?(걍 추측해봄))
