### PR TITLE
⚡️ fix: 행사 상세 페이지 오류 수정 및 헤더에 이름 표시

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     "_utils": "Utils",
     "_types": "Typescript",
     "_constants": "Constant",
+    "_styles": "CSS",
     "(route)": "Routes"
   },
   "tailwindCSS.rootFontSize": 10

--- a/app/(route)/(header)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/(header)/event/[eventId]/_components/Banner.tsx
@@ -89,7 +89,7 @@ const Banner = ({ data, eventId }: Props) => {
             <MapIcon {...IconStyleProps} />
             {`${data.address} ${data.addressDetail}`}
           </SubDescription>
-          <SubDescription>
+          <SubDescription isVisible={Boolean(data.eventTags.length !== 0)}>
             <GiftIcon {...IconStyleProps} />
             <div className="flex items-center gap-4">
               {data.eventTags.map((tag) => (

--- a/app/(route)/(header)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/(header)/event/[eventId]/_components/Banner.tsx
@@ -4,8 +4,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Api } from "app/_api/api";
 import Image from "next/image";
 import Link from "next/link";
-import { ButtonHTMLAttributes, ReactNode, useState } from "react";
+import { ButtonHTMLAttributes, ReactNode, useEffect, useState } from "react";
 import Chip from "@/components/chip/Chip";
+import { useStore } from "@/store/index";
 import { formatDate } from "@/utils/formatString";
 import { EventCardType, EventType, TargetArtistType } from "@/types/index";
 import CalendarIcon from "@/public/icon/calendar.svg";
@@ -40,6 +41,11 @@ interface Props {
 }
 
 const Banner = ({ data, eventId }: Props) => {
+  const { setEventHeader } = useStore((state) => ({ setEventHeader: state.setEventHeader }));
+  useEffect(() => {
+    setEventHeader(data.placeName);
+  }, []);
+
   const formattedDate = formatDate(data.startDate, data.endDate, true);
   const bannerImage = data.eventImages.find((images) => images.isMain);
   const formattedOrganizerSns = data.organizerSns[0] === "@" ? data.organizerSns : `@${data.organizerSns}`;

--- a/app/(route)/(header)/event/[eventId]/_components/EventReview.tsx
+++ b/app/(route)/(header)/event/[eventId]/_components/EventReview.tsx
@@ -14,7 +14,7 @@ const EventReview = ({ data }: Props) => {
     <div className="flex flex-col gap-16 border-b border-gray-50 px-20 py-16">
       <div className="flex items-center gap-8">
         <div className="relative h-32 w-32">
-          <Image src={data.user.profileImage ?? DEFAULT_PROFILE_IMAGE} alt="프로필 이미지" fill className="rounded-full object-cover" sizes="3.2rem" />
+          <Image src={data.user?.profileImage ?? DEFAULT_PROFILE_IMAGE} alt="프로필 이미지" fill className="rounded-full object-cover" sizes="3.2rem" />
         </div>
         <div className="text-16 font-500">{data.user.nickName}</div>
         <button className="ml-auto text-12 font-500 text-gray-400">신고하기</button>

--- a/app/_hooks/useHeaderTitle.tsx
+++ b/app/_hooks/useHeaderTitle.tsx
@@ -1,4 +1,5 @@
 import { useParams, usePathname } from "next/navigation";
+import { useStore } from "@/store/index";
 
 const useHeaderTitle = () => {
   const pathname = usePathname();
@@ -25,7 +26,8 @@ const useHeaderTitle = () => {
       title = "등록하기";
       break;
     case `/event/${eventId}`:
-      title = "카페 이름";
+      const { eventHeader } = useStore((state) => ({ eventHeader: state.eventHeader }));
+      title = eventHeader;
       break;
     case `/event/${eventId}/post`:
       title = "후기 작성하기";

--- a/app/_store/index.ts
+++ b/app/_store/index.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
+import { EventHeaderSlice, createEventHeaderSlice } from "./slice/eventHeaderSlice";
 import { WarningSlice, createWarningSlice } from "./slice/warningSlice";
 
-type SliceType = WarningSlice;
+type SliceType = WarningSlice & EventHeaderSlice;
 
 export const useStore = create<SliceType>()((...a) => ({
   ...createWarningSlice(...a),
+  ...createEventHeaderSlice(...a),
 }));

--- a/app/_store/slice/eventHeaderSlice.ts
+++ b/app/_store/slice/eventHeaderSlice.ts
@@ -1,0 +1,11 @@
+import { StateCreator } from "zustand";
+
+export interface EventHeaderSlice {
+  eventHeader: string;
+  setEventHeader: (s: string) => void;
+}
+
+export const createEventHeaderSlice: StateCreator<EventHeaderSlice> = (set) => ({
+  eventHeader: "",
+  setEventHeader: (eventHeader) => set((state) => ({ ...state, eventHeader })),
+});


### PR DESCRIPTION
## ✏️ 변경사항
- 행사 상세 페이지에서 후기 탭에 들어갔을 때 api에서 유저 프로필 이미지를 안보내줄 시 에러가 나던 현상을 수정했습니다.
- 특전이 없을 경우에 특전 칼럼이 안보이도록 수정했습니다.
- 행사 상세 페이지 헤더에 행사 장소 이름이 보이도록 수정했습니다.

## 📷 스크린샷
<img width="491" alt="스크린샷 2024-02-15 오후 7 57 05" src="https://github.com/P1Z7/frontend/assets/83965026/849807ec-4cf3-4ae5-b432-3848c60c78fb">

## 🎸 기타
- 현재 서버에 들어가 있는 값들 중에 여전히 후기 탭에서 오류가 나는 경우가 존재하나, 이는 api 테스트 과정에서 잘못된 데이터가 들어가서 그런 것으로 보입니다! 후기를 작성한 유저의 nickName은 필수적으로 보내주는 데이터로 처리를 해 놓았는데 없는 데이터가 존재합니다.