### PR TITLE
⚡️ fix & ✨ feat: 좋아요 버튼이 눌렸을 때에만 캐싱 되도록 수정, 검색 결과 수 및 좋아요 수 표시

### DIFF
--- a/app/(route)/(bottom-nav)/mypage/_components/tab/MyReviewTab/MyReview.tsx
+++ b/app/(route)/(bottom-nav)/mypage/_components/tab/MyReviewTab/MyReview.tsx
@@ -27,7 +27,6 @@ const MyReview = ({ data, userId }: Props) => {
       setLiked((prev) => !prev);
     },
   });
-  console.log(data.reviewArtists);
 
   return (
     <div className="flex w-full flex-col gap-16 border-b border-gray-50 px-20 py-16">

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -229,7 +229,12 @@ const SearchPage = () => {
             {isEmpty ? (
               <div className="flex-center w-full pt-36 text-14 font-500">검색 결과가 없습니다.</div>
             ) : (
-              events?.pages.map((page) => page.eventList.map((event) => <HorizontalEventCard key={event.id} data={event} />))
+              <>
+                {events?.pages[0].totalCount && (
+                  <div className="w-full pt-12 text-12 font-500 text-gray-800 pc:pt-[2.2rem] pc:text-14">{events?.pages[0].totalCount}개의 검색결과가 있습니다.</div>
+                )}
+                {events?.pages.map((page) => page.eventList.map((event) => <HorizontalEventCard key={event.id} data={event} />))}
+              </>
             )}
             {/* <DeferredSuspense fallback={<HorizontalEventCardSkeleton />} isFetching={isFetching} /> */}
             <div ref={containerRef} className="h-20 w-full" />

--- a/app/(route)/(bottom-nav)/search/page.tsx
+++ b/app/(route)/(bottom-nav)/search/page.tsx
@@ -13,6 +13,7 @@ import HorizontalEventCardSkeleton from "@/components/skeleton/HorizontalEventCa
 import { instance } from "@/api/api";
 import { useBottomSheet } from "@/hooks/useBottomSheet";
 import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+import { getSession } from "@/store/session/cookies";
 import { formatDate } from "@/utils/formatString";
 import { createQueryString } from "@/utils/handleQueryString";
 import { Res_Get_Type } from "@/types/getResType";
@@ -121,6 +122,7 @@ const SearchPage = () => {
   }, [keyword, sort, filter]);
 
   const queryClient = useQueryClient();
+  const session = getSession();
 
   const getEvents = async ({ pageParam = 1 }) => {
     const data: Res_Get_Type["eventSearch"] = await instance.get("/event", {
@@ -133,6 +135,7 @@ const SearchPage = () => {
       ...{ startDate: filter.startDate || "" },
       ...{ endDate: filter.endDate || "" },
       tags: filter.gifts.map((gift) => TAG[gift]).join(","),
+      userId: session?.user.userId ?? "",
     });
     return data;
   };

--- a/app/(route)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/event/[eventId]/_components/Banner.tsx
@@ -70,7 +70,7 @@ const Banner = ({ data, eventId }: Props) => {
           <Image src={bannerImage?.imageUrl ?? DefaultImage} alt={"행사 포스터 썸네일"} priority fill sizes="250px" className="object-cover" />
         </div>
         <div className="relative bottom-24 grow rounded-t-lg bg-white-black p-24 pb-0 pc:bottom-0 pc:p-0">
-          <HeartButton eventId={data.id} initialLikeCount={data.likeCount} />
+          <HeartButton eventId={data.id} initialLike={data.isLike} initialLikeCount={data.likeCount} />
           <MainDescription placeName={data.placeName} artists={data.targetArtists} eventType={data.eventType} />
           <div className="flex flex-col gap-8 pt-16 text-14 font-500 pc:gap-20 pc:pt-24">
             <SubDescription>

--- a/app/(route)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/event/[eventId]/_components/Banner.tsx
@@ -14,6 +14,7 @@ import { useStore } from "@/store/index";
 import { formatDate } from "@/utils/formatString";
 import { Res_Get_Type } from "@/types/getResType";
 import { EventCardType, EventType, TargetArtistType } from "@/types/index";
+import { TAG_ORDER } from "@/constants/data";
 import { SnsIcon } from "@/constants/snsIcon";
 import CalendarIcon from "@/public/icon/calendar.svg";
 import GiftIcon from "@/public/icon/gift.svg";
@@ -99,9 +100,11 @@ const Banner = ({ data, eventId }: Props) => {
                 <GiftIcon {...IconStyleProps.pc} />
               </div>
               <div className="flex flex-wrap items-center gap-4 pc:gap-8">
-                {data.eventTags.map((tag) => (
-                  <Chip key={tag.tagId} kind="goods" label={tag.tagName} />
-                ))}
+                {data.eventTags
+                  .sort((a, b) => TAG_ORDER[a.tagId].order - TAG_ORDER[b.tagId].order)
+                  .map((tag) => (
+                    <Chip key={tag.tagId} kind="goods" label={tag.tagName} />
+                  ))}
               </div>
             </SubDescription>
             <SubDescription isVisible={Boolean(data.eventUrl)}>

--- a/app/(route)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/event/[eventId]/_components/Banner.tsx
@@ -160,7 +160,7 @@ const MainDescription = ({ placeName, artists, eventType }: MainDescriptionProps
 
   return (
     <div className="flex flex-col gap-8 border-b border-gray-100 pb-16 pc:gap-12 pc:pb-32">
-      <h1 className="h-24 text-20 font-600 pc:text-[2.8rem] pc:leading-[2.4rem]">{placeName}</h1>
+      <h1 className="pr-20 text-20 font-600 pc:text-[2.8rem] pc:leading-[2.4rem]">{placeName}</h1>
       <div className="flex items-center gap-8">
         <span className="text-16 font-600 pc:max-w-308 pc:text-20">{formattedArtist}</span>
         <Chip kind="event" label={eventType} />

--- a/app/(route)/event/[eventId]/_components/HeartButton.tsx
+++ b/app/(route)/event/[eventId]/_components/HeartButton.tsx
@@ -6,11 +6,12 @@ import HeartIcon from "@/public/icon/heart.svg";
 
 interface HeartButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   eventId: string;
+  initialLike: boolean;
   initialLikeCount: number;
 }
 
-const HeartButton = ({ eventId, initialLikeCount }: HeartButtonProps) => {
-  const { liked, likeCount, handleLikeEvent } = useLikeEvent({ eventId, initialLikeCount });
+const HeartButton = ({ eventId, initialLike, initialLikeCount }: HeartButtonProps) => {
+  const { liked, likeCount, handleLikeEvent } = useLikeEvent({ eventId, initialLike, initialLikeCount });
 
   return (
     <button onClick={handleLikeEvent} className="absolute right-20 top-24 text-center text-12 font-600 pc:right-0 pc:top-0 pc:text-14">

--- a/app/(route)/event/[eventId]/page.tsx
+++ b/app/(route)/event/[eventId]/page.tsx
@@ -1,3 +1,4 @@
+import { cookies } from "next/headers";
 import MetaTag from "@/components/MetaTag";
 import Tabs from "@/components/Tabs";
 import MobileHeader from "@/components/header/MobileHeader";
@@ -13,7 +14,9 @@ interface Props {
 }
 
 const getEventInfo = async (eventId: string) => {
-  const data = await fetch(`https://${process.env.NEXT_PUBLIC_BASE_URL}/event/${eventId}`, { cache: "no-store" });
+  const cookieStore = cookies();
+  const session = JSON.parse(cookieStore.get("session")?.value ?? "");
+  const data = await fetch(`https://${process.env.NEXT_PUBLIC_BASE_URL}/event/${eventId}?userId=${session?.user.userId}`, { cache: "no-store" });
   const res: Res_Get_Type["event"] = await data.json();
   return res;
 };

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -19,7 +19,7 @@ const HorizontalEventCard = ({ data, onHeartClick, isGrow = false }: Props) => {
   const formattedDate = formatDate(data.startDate, data.endDate);
   const formattedAddress = formatAddress(data.address);
 
-  const { liked, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLike: data.isLike, initialLikeCount: data.likeCount });
+  const { liked, likeCount, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLike: data.isLike, initialLikeCount: data.likeCount });
 
   const handleClick = async () => {
     if (onHeartClick) {
@@ -35,8 +35,12 @@ const HorizontalEventCard = ({ data, onHeartClick, isGrow = false }: Props) => {
       href={`/event/${data.id}`}
       className={`relative flex w-full ${isGrow ? "" : "pc:max-w-[50.8rem]"} items-center gap-12 border-b border-gray-50 bg-white-black py-12 pc:gap-20 pc:py-20`}
     >
-      <div className="absolute right-0 top-[1.3rem] z-heart pc:top-[2.75rem]" onClick={(e: SyntheticEvent) => e.preventDefault()}>
+      <div
+        className="flex-center absolute right-0 top-[1.3rem] z-heart flex-col text-12 font-500 text-gray-500 pc:top-[2.75rem]"
+        onClick={(e: SyntheticEvent) => e.preventDefault()}
+      >
         <HeartButton isSmall isSelected={liked} onClick={handleClick} />
+        <div className="relative bottom-4">{likeCount}</div>
       </div>
       <div className="relative h-112 w-84 shrink-0 pc:h-152 pc:w-116">
         <Image src={data.eventImages?.[0]?.imageUrl ?? NoImage} className="rounded-[0.4rem] object-cover" fill alt="행사 포스터" sizes="116px" priority />

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -19,7 +19,7 @@ const HorizontalEventCard = ({ data, onHeartClick, isGrow = false }: Props) => {
   const formattedDate = formatDate(data.startDate, data.endDate);
   const formattedAddress = formatAddress(data.address);
 
-  const { liked, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLikeCount: data.likeCount });
+  const { liked, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLike: data.isLike, initialLikeCount: data.likeCount });
 
   const handleClick = async () => {
     if (onHeartClick) {

--- a/app/_components/card/VerticalEventCard.tsx
+++ b/app/_components/card/VerticalEventCard.tsx
@@ -16,7 +16,7 @@ const VerticalEventCard = ({ data }: Props) => {
   const formattedAddress = formatAddress(data.address);
   const bannerImage = data.eventImages.find((images) => images.isMain);
 
-  const { liked, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLikeCount: data.likeCount });
+  const { liked, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLike: data.isLike, initialLikeCount: data.likeCount });
 
   return (
     <Link href={`/event/${data.id}`} className="flex w-148 cursor-pointer flex-col gap-12 pc:w-188">

--- a/app/_components/header/MobileHeader.tsx
+++ b/app/_components/header/MobileHeader.tsx
@@ -40,7 +40,7 @@ const MobileHeader = ({ handleClick }: Props) => {
         <button onClick={handleClick || (() => router.back())} className="z-nav">
           <ArrowLeft />
         </button>
-        <h1 className="absolute left-0 w-full text-center text-16 font-600 text-gray-900">{title}</h1>
+        <h1 className="absolute left-0 w-full truncate px-60 text-center text-16 font-600 text-gray-900">{title}</h1>
         {pathname === `/event/${eventId}` && (
           <button onClick={openKebabBottomSheet} className="z-nav">
             <KebabButton />

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -159,10 +159,11 @@ export interface EventCardType {
   createdAt: string;
   updatedAt?: string | null;
   deletedAt?: string | null;
-  likeCount: number;
   eventImages: EventImageType[];
   targetArtists: TargetArtistType[];
   eventTags: EventTagType[];
+  isLike: boolean;
+  likeCount: number;
 }
 
 export interface EventReviewType {

--- a/app/_types/queryType.ts
+++ b/app/_types/queryType.ts
@@ -8,6 +8,7 @@ type Req_Query_Event = {
   sort?: "최신순" | "인기순";
   page?: number;
   size?: number;
+  userId?: string;
 };
 
 type Req_Query_Event_Detail = {
@@ -64,7 +65,7 @@ type Req_Query_Approve = {
 };
 
 type Req_Query_Artist_Event = {
-  sort: "최신순" | "인기순"
+  sort: "최신순" | "인기순";
   size?: number;
   page?: number;
   userId: string;
@@ -72,7 +73,7 @@ type Req_Query_Artist_Event = {
 
 type Req_Query_Artist_New_Event = {
   userId: string;
-}
+};
 
 export type Req_Query_Type = {
   행사목록: Req_Query_Event;
@@ -88,5 +89,5 @@ export type Req_Query_Type = {
   멤버조회: Req_Query_Artist;
   수정상세: Req_Query_Approve;
   아티스트행사: Req_Query_Artist_Event;
-  아티스트새행사: Req_Query_Artist_New_Event
+  아티스트새행사: Req_Query_Artist_New_Event;
 };


### PR DESCRIPTION
## ✏️ 변경사항
- 좋아요 버튼을 매번 다시 요청을 보내 캐싱하지 않고 눌렀을 때에만 캐싱이 이루어지도록 수정했습니다.
- 검색 결과 수가 표시되도록 했습니다.
- 가로형 카드에서 좋아요 수가 보이도록 했습니다.
