### PR TITLE
✨ feat: 아티스트 페이지 바텀 시트 드래그 구현

### DIFF
--- a/app/(route)/artist/[artistId]/_components/MobileTab.tsx
+++ b/app/(route)/artist/[artistId]/_components/MobileTab.tsx
@@ -1,0 +1,71 @@
+import SortButton from "@/(route)/search/_components/SortButton";
+import Image from "next/image";
+import { Dispatch, SetStateAction } from "react";
+import TimeFilter from "@/components/TimeFilter";
+import { MapCallbackType, MapVarType } from "@/hooks/useCustomMap";
+import { EventCardType } from "@/types/index";
+import SortIcon from "@/public/icon/sort.svg";
+import EventCard from "./EventCard";
+
+interface Props {
+  mapVar: MapVarType;
+  mapCallback: MapCallbackType;
+  image: string;
+  name: string;
+  status: number;
+  setStatus: Dispatch<SetStateAction<number>>;
+  sort: "최신순" | "인기순";
+  setSort: Dispatch<SetStateAction<"최신순" | "인기순">>;
+  eventData: EventCardType[];
+}
+
+const MobileTab = ({ mapVar, mapCallback, image, name, status, setStatus, sort, setSort, eventData }: Props) => {
+  const isEmpty = eventData.length === 0;
+
+  return (
+    <>
+      {mapVar.toggleTab && (
+        <div className="absolute bottom-0 flex max-h-352 min-h-84 w-full flex-col gap-16 rounded-t-lg bg-white-black pt-28 shadow-2xl tablet:hidden">
+          <div className="absolute left-[calc((100%-64px)/2)] top-12 h-4 w-64 rounded-sm bg-gray-700 tablet:hidden" />
+          <div className="flex flex-row items-center justify-start gap-12 px-20 pc:w-full">
+            <div className="relative h-36 w-36 pc:h-64 pc:w-64">
+              <Image src={image ?? "/image/no-profile.png"} alt="아티스트 이미지" fill sizes="64px" className="rounded-full object-cover" />
+            </div>
+            <p className="text-16 leading-[2.4rem] text-gray-700">
+              <span className="font-600">{name}</span> 행사 보기
+            </p>
+          </div>
+          <TimeFilter setStatus={setStatus} status={status} />
+          <div className="flex items-center gap-8 px-20">
+            <SortIcon />
+            <SortButton onClick={() => setSort("최신순")} selected={sort === "최신순"}>
+              최신순
+            </SortButton>
+            <SortButton onClick={() => setSort("인기순")} selected={sort === "인기순"}>
+              인기순
+            </SortButton>
+          </div>
+          <div className="min-h-200 overflow-scroll scrollbar-none pc:h-[65rem]">
+            {isEmpty ? (
+              <p className="flex-center w-full pt-20 text-14 font-500">행사가 없습니다.</p>
+            ) : (
+              <div className="px-20">
+                {eventData.map((event) => (
+                  <EventCard
+                    key={event.id}
+                    data={event}
+                    isSelected={mapVar.selectedCard?.id === event.id}
+                    onCardClick={() => mapCallback.handleCardClick(event)}
+                    scrollRef={mapVar.selectedCard?.id === event.id ? mapCallback.scrollRefCallback : null}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MobileTab;

--- a/app/(route)/artist/[artistId]/_components/MobileTab.tsx
+++ b/app/(route)/artist/[artistId]/_components/MobileTab.tsx
@@ -5,6 +5,7 @@ import TimeFilter from "@/components/TimeFilter";
 import { MapCallbackType, MapVarType } from "@/hooks/useCustomMap";
 import { EventCardType } from "@/types/index";
 import SortIcon from "@/public/icon/sort.svg";
+import useArtistSheet from "../_hooks/useArtistSheet";
 import EventCard from "./EventCard";
 
 interface Props {
@@ -22,49 +23,50 @@ interface Props {
 const MobileTab = ({ mapVar, mapCallback, image, name, status, setStatus, sort, setSort, eventData }: Props) => {
   const isEmpty = eventData.length === 0;
 
+  const { sheet, content } = useArtistSheet();
+
   return (
-    <>
-      {mapVar.toggleTab && (
-        <div className="absolute bottom-0 flex max-h-352 min-h-84 w-full flex-col gap-16 rounded-t-lg bg-white-black pt-28 shadow-2xl tablet:hidden">
-          <div className="absolute left-[calc((100%-64px)/2)] top-12 h-4 w-64 rounded-sm bg-gray-700 tablet:hidden" />
-          <div className="flex flex-row items-center justify-start gap-12 px-20 pc:w-full">
-            <div className="relative h-36 w-36 pc:h-64 pc:w-64">
-              <Image src={image ?? "/image/no-profile.png"} alt="아티스트 이미지" fill sizes="64px" className="rounded-full object-cover" />
-            </div>
-            <p className="text-16 leading-[2.4rem] text-gray-700">
-              <span className="font-600">{name}</span> 행사 보기
-            </p>
-          </div>
-          <TimeFilter setStatus={setStatus} status={status} />
-          <div className="flex items-center gap-8 px-20">
-            <SortIcon />
-            <SortButton onClick={() => setSort("최신순")} selected={sort === "최신순"}>
-              최신순
-            </SortButton>
-            <SortButton onClick={() => setSort("인기순")} selected={sort === "인기순"}>
-              인기순
-            </SortButton>
-          </div>
-          <div className="min-h-200 overflow-scroll scrollbar-none pc:h-[65rem]">
-            {isEmpty ? (
-              <p className="flex-center w-full pt-20 text-14 font-500">행사가 없습니다.</p>
-            ) : (
-              <div className="px-20">
-                {eventData.map((event) => (
-                  <EventCard
-                    key={event.id}
-                    data={event}
-                    isSelected={mapVar.selectedCard?.id === event.id}
-                    onCardClick={() => mapCallback.handleCardClick(event)}
-                    scrollRef={mapVar.selectedCard?.id === event.id ? mapCallback.scrollRefCallback : null}
-                  />
-                ))}
-              </div>
-            )}
-          </div>
+    <div
+      ref={sheet}
+      className="absolute top-[calc(100vh-384px)] flex min-h-84 w-full flex-col gap-16 rounded-t-lg bg-white-black pt-28 shadow-2xl transition duration-150 ease-out tablet:hidden"
+    >
+      <div className="absolute left-[calc((100%-64px)/2)] top-12 h-4 w-64 rounded-sm bg-gray-700 tablet:hidden" />
+      <div className="flex flex-row items-center justify-start gap-12 px-20 pc:w-full">
+        <div className="relative h-36 w-36 pc:h-64 pc:w-64">
+          <Image src={image ?? "/image/no-profile.png"} alt="아티스트 이미지" fill sizes="64px" className="rounded-full object-cover" />
         </div>
-      )}
-    </>
+        <p className="text-16 leading-[2.4rem] text-gray-700">
+          <span className="font-600">{name}</span> 행사 보기
+        </p>
+      </div>
+      <TimeFilter setStatus={setStatus} status={status} />
+      <div className="flex items-center gap-8 px-20">
+        <SortIcon />
+        <SortButton onClick={() => setSort("최신순")} selected={sort === "최신순"}>
+          최신순
+        </SortButton>
+        <SortButton onClick={() => setSort("인기순")} selected={sort === "인기순"}>
+          인기순
+        </SortButton>
+      </div>
+      <div ref={content} className="max-h-[80rem] min-h-200 overflow-scroll pb-[70rem] scrollbar-none">
+        {isEmpty ? (
+          <p className="flex-center w-full pt-20 text-14 font-500">행사가 없습니다.</p>
+        ) : (
+          <div className="px-20">
+            {eventData.map((event) => (
+              <EventCard
+                key={event.id}
+                data={event}
+                isSelected={mapVar.selectedCard?.id === event.id}
+                onCardClick={() => mapCallback.handleCardClick(event)}
+                scrollRef={mapVar.selectedCard?.id === event.id ? mapCallback.scrollRefCallback : null}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/app/(route)/artist/[artistId]/_components/PcTab.tsx
+++ b/app/(route)/artist/[artistId]/_components/PcTab.tsx
@@ -1,0 +1,70 @@
+import SortButton from "@/(route)/search/_components/SortButton";
+import Image from "next/image";
+import { Dispatch, SetStateAction } from "react";
+import TimeFilter from "@/components/TimeFilter";
+import { MapCallbackType, MapVarType } from "@/hooks/useCustomMap";
+import { EventCardType } from "@/types/index";
+import SortIcon from "@/public/icon/sort.svg";
+import EventCard from "./EventCard";
+
+interface Props {
+  mapVar: MapVarType;
+  mapCallback: MapCallbackType;
+  image: string;
+  name: string;
+  status: number;
+  setStatus: Dispatch<SetStateAction<number>>;
+  sort: "최신순" | "인기순";
+  setSort: Dispatch<SetStateAction<"최신순" | "인기순">>;
+  eventData: EventCardType[];
+}
+
+const PcTab = ({ mapVar, mapCallback, image, name, status, setStatus, sort, setSort, eventData }: Props) => {
+  const isEmpty = eventData.length === 0;
+
+  return (
+    <>
+      {mapVar.toggleTab && (
+        <div className="tablet:rounded-none absolute bottom-0 top-0 hidden max-h-full min-h-84 w-360 flex-col gap-16 rounded-t-lg border border-gray-100 border-t-transparent bg-white-black pt-20 shadow-none tablet:flex pc:top-0 pc:h-[84rem] pc:w-400 pc:rounded-l-lg pc:border-t-gray-100 pc:py-20">
+          <div className="flex flex-row items-center justify-start gap-12 px-20 pc:w-full">
+            <div className="relative h-36 w-36 pc:h-64 pc:w-64">
+              <Image src={image ?? "/image/no-profile.png"} alt="아티스트 이미지" fill sizes="64px" className="rounded-full object-cover" />
+            </div>
+            <p className="text-16 leading-[2.4rem] text-gray-700">
+              <span className="font-600">{name}</span> 행사 보기
+            </p>
+          </div>
+          <TimeFilter setStatus={setStatus} status={status} />
+          <div className="flex items-center gap-8 px-20">
+            <SortIcon />
+            <SortButton onClick={() => setSort("최신순")} selected={sort === "최신순"}>
+              최신순
+            </SortButton>
+            <SortButton onClick={() => setSort("인기순")} selected={sort === "인기순"}>
+              인기순
+            </SortButton>
+          </div>
+          <div className="min-h-200 overflow-scroll scrollbar-none pc:h-[65rem]">
+            {isEmpty ? (
+              <p className="flex-center w-full pt-20 text-14 font-500">행사가 없습니다.</p>
+            ) : (
+              <div className="px-20">
+                {eventData.map((event) => (
+                  <EventCard
+                    key={event.id}
+                    data={event}
+                    isSelected={mapVar.selectedCard?.id === event.id}
+                    onCardClick={() => mapCallback.handleCardClick(event)}
+                    scrollRef={mapVar.selectedCard?.id === event.id ? mapCallback.scrollRefCallback : null}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default PcTab;

--- a/app/(route)/artist/[artistId]/_hooks/useArtistSheet.tsx
+++ b/app/(route)/artist/[artistId]/_hooks/useArtistSheet.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface BottomSheetMetrics {
+  touchStart: number;
+  position: number;
+  isContentAreaTouched: boolean;
+}
+
+const SNAP = {
+  top: 280,
+  bottom: 670,
+};
+
+const useArtistSheet = () => {
+  const metrics = useRef<BottomSheetMetrics>({
+    touchStart: 0,
+    position: 0,
+    isContentAreaTouched: false,
+  });
+
+  const sheet = useCallback((node: HTMLElement | null) => {
+    if (node !== null) {
+      const handleTouchStart = (e: TouchEvent) => {
+        metrics.current.touchStart = e.touches[0].clientY;
+      };
+
+      const handleTouchMove = (e: TouchEvent) => {
+        const { touchStart, isContentAreaTouched, position } = metrics.current;
+        const currentTouch = e.touches[0];
+
+        if (!isContentAreaTouched) {
+          e.preventDefault();
+          const touchOffset = currentTouch.clientY - touchStart + position;
+          node.style.setProperty("transform", `translateY(${touchOffset}px)`);
+        }
+      };
+
+      const handleTouchEnd = (e: TouchEvent) => {
+        const currentY = node.getBoundingClientRect().y;
+
+        if (currentY > SNAP.bottom) {
+          node.style.setProperty("transform", `translateY(240px)`);
+          metrics.current.position = 240;
+        } else if (currentY < SNAP.bottom && currentY > SNAP.top) {
+          node.style.setProperty("transform", "translateY(0px)");
+          metrics.current.position = 0;
+        } else if (currentY < SNAP.top) {
+          node.style.setProperty("transform", `translateY(-360px)`);
+          metrics.current.position = -360;
+        }
+
+        metrics.current.isContentAreaTouched = false;
+      };
+
+      node.addEventListener("touchstart", handleTouchStart);
+      node.addEventListener("touchmove", handleTouchMove);
+      node.addEventListener("touchend", handleTouchEnd);
+    }
+  }, []);
+
+  const content = useCallback((node: HTMLElement | null) => {
+    if (node !== null) {
+      const handleTouchStart = () => {
+        metrics.current.isContentAreaTouched = true;
+      };
+
+      node.addEventListener("touchstart", handleTouchStart);
+    }
+  }, []);
+
+  return { sheet, content };
+};
+
+export default useArtistSheet;

--- a/app/(route)/artist/[artistId]/_hooks/useArtistSheet.tsx
+++ b/app/(route)/artist/[artistId]/_hooks/useArtistSheet.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 
 interface BottomSheetMetrics {
   touchStart: number;

--- a/app/(route)/artist/[artistId]/page.tsx
+++ b/app/(route)/artist/[artistId]/page.tsx
@@ -1,22 +1,18 @@
 "use client";
 
-import SortButton from "@/(route)/search/_components/SortButton";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import KakaoMap from "@/components/KakaoMap";
-import TimeFilter from "@/components/TimeFilter";
 import DottedLayout from "@/components/layout/DottedLayout";
 import { instance } from "@/api/api";
 import useCustomMap from "@/hooks/useCustomMap";
-import useInfiniteScroll from "@/hooks/useInfiniteScroll";
-import { getSession } from "@/store/session/cookies";
 import { getArtist, getGroup } from "@/utils/getArtist";
 import { Res_Get_Type } from "@/types/getResType";
 import { SORT, STATUS, SortItem } from "@/constants/eventStatus";
-import SortIcon from "@/public/icon/sort.svg";
-import EventCard from "./_components/EventCard";
+import MobileTab from "./_components/MobileTab";
+import PcTab from "./_components/PcTab";
 
 const SIZE = 9999;
 
@@ -32,35 +28,19 @@ const ArtistIdPage = () => {
   const [sort, setSort] = useState<SortItem>(SORT[0]);
   const [status, setStatus] = useState(3);
 
-  const session = getSession();
-
-  const getArtistData = async ({ pageParam = 1 }) => {
-    const data: Res_Get_Type["eventSearch"] = await instance.get(`/event/artist/${artistId}`, {
-      sort,
-      size: SIZE,
-      page: pageParam,
-      status: STATUS[status],
-      userId: session?.user.userId ?? "",
-      artistId,
-    });
-    return data;
-  };
-
   const {
     data: artistData,
-    fetchNextPage,
     isSuccess,
     refetch,
-  } = useInfiniteQuery({
-    initialPageParam: 1,
+  } = useQuery<Res_Get_Type["eventSearch"]>({
     queryKey: ["events", artistId],
-    queryFn: getArtistData,
-    getNextPageParam: (lastPage) => (lastPage.page * SIZE < lastPage.totalCount ? lastPage.page + 1 : null),
-  });
-
-  const containerRef = useInfiniteScroll({
-    handleScroll: fetchNextPage,
-    deps: [artistData],
+    queryFn: () =>
+      instance.get(`/event/artist/${artistId}`, {
+        sort,
+        size: SIZE,
+        status: STATUS[status],
+        artistId,
+      }),
   });
 
   useEffect(() => {
@@ -71,16 +51,15 @@ const ArtistIdPage = () => {
 
   if (!isSuccess) return;
 
-  const isEmpty = artistData.pages[0].eventList.length === 0;
-  const mapData = artistData.pages[0].eventList;
+  const eventData = artistData.eventList;
 
   return (
     <DottedLayout size="wide">
       <div className="relative h-[calc(100vh-7.2rem)] w-full overflow-hidden pc:mb-128 pc:mt-48 pc:h-[84rem]">
         <div
-          className={`absolute left-0 top-0 z-zero h-full w-full ${mapVar.toggleTab ? "tablet:pl-360 pc:pl-400" : ""} pb-344 tablet:pb-0 pc:h-[84rem] pc:rounded-lg pc:border pc:border-gray-100`}
+          className={`z-zero absolute left-0 top-0 h-full w-full ${mapVar.toggleTab ? "tablet:pl-360 pc:pl-400" : ""} pb-344 tablet:pb-0 pc:h-[84rem] pc:rounded-lg pc:border pc:border-gray-100`}
         >
-          <KakaoMap scheduleData={mapData} {...mapVar} />
+          <KakaoMap scheduleData={eventData} {...mapVar} />
         </div>
         <button
           onClick={mapCallback.handleButtonClick}
@@ -88,49 +67,8 @@ const ArtistIdPage = () => {
         >
           <Image src="/icon/arrow-left.svg" width={20} height={20} alt="화살표" className={`${mapVar.toggleTab || "scale-x-[-1]"}`} />
         </button>
-        {mapVar.toggleTab && (
-          <div className="absolute bottom-0 flex max-h-352 min-h-84 w-full flex-col gap-16 rounded-t-lg bg-white-black pt-28 shadow-2xl tablet:top-0 tablet:max-h-full tablet:w-360 tablet:rounded-none tablet:border tablet:border-gray-100 tablet:border-t-transparent tablet:pt-20 tablet:shadow-none pc:top-0 pc:h-[84rem] pc:w-400 pc:rounded-l-lg pc:border-t-gray-100 pc:py-20">
-            <div className="absolute left-[calc((100%-64px)/2)] top-12 h-4 w-64 rounded-sm bg-gray-700 tablet:hidden" />
-            <div className="flex flex-row items-center justify-start gap-12 px-20 pc:w-full">
-              <div className="relative h-36 w-36 pc:h-64 pc:w-64">
-                <Image src={image ? image : "/image/no-profile.png"} alt="아티스트 이미지" fill sizes="64px" className="rounded-full object-cover" />
-              </div>
-              <p className="text-16 leading-[2.4rem] text-gray-700">
-                <span className="font-600">{name}</span> 행사 보기
-              </p>
-            </div>
-            <TimeFilter setStatus={setStatus} status={status} />
-            <div className="flex items-center gap-8 px-20">
-              <SortIcon />
-              <SortButton onClick={() => setSort("최신순")} selected={sort === "최신순"}>
-                최신순
-              </SortButton>
-              <SortButton onClick={() => setSort("인기순")} selected={sort === "인기순"}>
-                인기순
-              </SortButton>
-            </div>
-            <div className="min-h-200 overflow-scroll scrollbar-none pc:h-[65rem]">
-              {isEmpty ? (
-                <p className="flex-center w-full pt-20 text-14 font-500">행사가 없습니다.</p>
-              ) : (
-                <div className="px-20">
-                  {artistData.pages.map((page) =>
-                    page.eventList.map((event) => (
-                      <EventCard
-                        key={event.id}
-                        data={event}
-                        isSelected={mapVar.selectedCard?.id === event.id}
-                        onCardClick={() => mapCallback.handleCardClick(event)}
-                        scrollRef={mapVar.selectedCard?.id === event.id ? mapCallback.scrollRefCallback : null}
-                      />
-                    )),
-                  )}
-                </div>
-              )}
-              <div ref={containerRef} className="h-20 w-full" />
-            </div>
-          </div>
-        )}
+        <PcTab mapVar={mapVar} mapCallback={mapCallback} eventData={eventData} name={name} image={image} sort={sort} setSort={setSort} status={status} setStatus={setStatus} />
+        <MobileTab mapVar={mapVar} mapCallback={mapCallback} eventData={eventData} name={name} image={image} sort={sort} setSort={setSort} status={status} setStatus={setStatus} />
       </div>
     </DottedLayout>
   );

--- a/app/(route)/artist/[artistId]/page.tsx
+++ b/app/(route)/artist/[artistId]/page.tsx
@@ -57,7 +57,7 @@ const ArtistIdPage = () => {
     <DottedLayout size="wide">
       <div className="relative h-[calc(100vh-7.2rem)] w-full overflow-hidden pc:mb-128 pc:mt-48 pc:h-[84rem]">
         <div
-          className={`z-zero absolute left-0 top-0 h-full w-full ${mapVar.toggleTab ? "tablet:pl-360 pc:pl-400" : ""} pb-344 tablet:pb-0 pc:h-[84rem] pc:rounded-lg pc:border pc:border-gray-100`}
+          className={`z-zero absolute left-0 top-0 h-full w-full ${mapVar.toggleTab ? "tablet:pl-360 pc:pl-400" : ""} tablet:pb-0 pc:h-[84rem] pc:rounded-lg pc:border pc:border-gray-100`}
         >
           <KakaoMap scheduleData={eventData} {...mapVar} />
         </div>

--- a/app/(route)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/event/[eventId]/_components/Banner.tsx
@@ -176,7 +176,7 @@ const MainDescription = ({ placeName, artists, eventType }: MainDescriptionProps
 
   return (
     <div className="flex flex-col gap-8 border-b border-gray-100 pb-16 pc:gap-12 pc:pb-32">
-      <h1 className="pr-20 text-20 font-600 pc:text-[2.8rem] pc:leading-[2.4rem]">{placeName}</h1>
+      <h1 className="pr-32 text-20 font-600 pc:text-[2.8rem] pc:leading-[2.8rem]">{placeName}</h1>
       <div className="flex items-center gap-8">
         <span className="text-16 font-600 pc:max-w-308 pc:text-20">{formattedArtist}</span>
         <Chip kind="event" label={eventType} />

--- a/app/(route)/event/[eventId]/_components/Banner.tsx
+++ b/app/(route)/event/[eventId]/_components/Banner.tsx
@@ -145,7 +145,7 @@ const Banner = ({ data, eventId }: Props) => {
             </SubDescription>
             {hasEditApplication && <Alert href={pathname + "/approve"} message="수정요청 정보가 있습니다." />}
           </div>
-          <div className="absolute bottom-0 right-0 hidden text-14 font-400 pc:block">
+          <div className="bottom-0 right-0 pt-12 text-12 font-400 pc:absolute pc:block pc:text-14">
             <Link href={pathname + "/edit"} className="mr-16 text-blue">
               수정하기
             </Link>

--- a/app/(route)/mypage/_components/UserProfile.tsx
+++ b/app/(route)/mypage/_components/UserProfile.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useAuth } from "@/hooks/useAuth";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import SettingList from "./SettingList";
 
 const MyPageBottomSheet = dynamic(() => import("@/components/bottom-sheet/MyPageBottomSheet"), { ssr: false });

--- a/app/(route)/mypage/_components/tab/MyReviewTab/MyReview.tsx
+++ b/app/(route)/mypage/_components/tab/MyReviewTab/MyReview.tsx
@@ -6,7 +6,7 @@ import ControlMyDataBottomSheet from "@/components/bottom-sheet/ControlMyDataBot
 import KebabContents from "@/components/card/KebabContents";
 import Chip from "@/components/chip/Chip";
 import { instance } from "@/api/api";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import { formatAddress, formatDate } from "@/utils/formatString";
 import { MyReviewType } from "@/types/index";
 import HeartIcon from "@/public/icon/heart.svg";

--- a/app/(route)/page.tsx
+++ b/app/(route)/page.tsx
@@ -11,7 +11,7 @@ const Home = () => {
     <>
       <MetaTag />
       <DottedLayout size="wide">
-        <div className="flex flex-col pb-72 pt-16 tablet:pt-36 pc:items-center pc:pb-0 pc:pt-56">
+        <div className="flex flex-col pb-72 pt-24 tablet:pt-36 pc:items-center pc:pb-0 pc:pt-56">
           <main className="flex flex-col gap-40 overflow-hidden pc:w-[112rem]">
             <SearchBar />
             <ArtistOfMonth />

--- a/app/(route)/post/_components/_inputs/MainInput.tsx
+++ b/app/(route)/post/_components/_inputs/MainInput.tsx
@@ -2,7 +2,7 @@ import InitButton from "@/(route)/event/[eventId]/edit/_components/InitButton";
 import dynamic from "next/dynamic";
 import { useFormContext } from "react-hook-form";
 import InputText from "@/components/input/InputText";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import { validateEdit } from "@/utils/editValidate";
 import { handleEnterDown } from "@/utils/handleEnterDown";
 import { PostType } from "../../page";

--- a/app/(route)/post/_components/_inputs/StarInput.tsx
+++ b/app/(route)/post/_components/_inputs/StarInput.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 import EventTypeList from "@/components/bottom-sheet/content/EventTypeList";
 import InputText from "@/components/input/InputText";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import useGetWindowWidth from "@/hooks/useGetWindowWidth";
 import { useModal } from "@/hooks/useModal";
 import { checkArrUpdate } from "@/utils/checkArrUpdate";

--- a/app/(route)/search/_components/Filter.tsx
+++ b/app/(route)/search/_components/Filter.tsx
@@ -37,7 +37,7 @@ const Filter = ({ visible, filter, resetFilter, sort, handleSort, status, handle
   return (
     <div className={`animate-fadeIn flex-col gap-12 px-20 pb-8 pc:p-0 ${visible ? "flex" : "hidden pc:block"}`}>
       <div className="flex w-full gap-8 overflow-auto scrollbar-hide">
-        <button onClick={resetFilter} type="button" className="flex-center h-32 w-32 rounded-full bg-gray-50">
+        <button onClick={resetFilter} type="button" className="flex-center h-32 w-32 shrink-0 rounded-full bg-gray-50">
           <ResetIcon />
         </button>
         <FilterButton onClick={openSearchBottomSheet.bigRegion} selected={Boolean(filter.bigRegion)}>

--- a/app/(route)/search/_hooks/useSearch.tsx
+++ b/app/(route)/search/_hooks/useSearch.tsx
@@ -2,7 +2,7 @@ import dynamic from "next/dynamic";
 import { ReadonlyURLSearchParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { EVENTS } from "@/components/bottom-sheet/EventBottomSheet";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import { createQueryString } from "@/utils/handleQueryString";
 import { EventType, GiftType, StatusType } from "@/types/index";
 import { BIG_REGIONS } from "@/constants/regions";

--- a/app/_components/bottom-sheet/BottomSheetMaterial.tsx
+++ b/app/_components/bottom-sheet/BottomSheetMaterial.tsx
@@ -13,7 +13,7 @@ interface BottomSheetFrameProps {
 const BottomSheetFrame = forwardRef<HTMLDivElement, BottomSheetFrameProps>(({ children, closeBottomSheet }, ref) => {
   return (
     <BottomSheetPortal>
-      <div onClick={closeBottomSheet} className="fixed bottom-0 left-0 z-popup flex h-screen w-full items-end justify-center bg-gray-900 bg-opacity-70 pc:items-center">
+      <div onClick={closeBottomSheet} className="fixed bottom-0 left-0 z-[1002] flex h-screen w-full items-end justify-center bg-gray-900 bg-opacity-70 pc:items-center">
         <div
           ref={ref}
           onClick={(e: SyntheticEvent) => e.stopPropagation()}

--- a/app/_components/bottom-sheet/EventBottomSheet.tsx
+++ b/app/_components/bottom-sheet/EventBottomSheet.tsx
@@ -23,7 +23,7 @@ const EventBottomSheet = ({ closeBottomSheet, refs, setEventFilter, selected }: 
       <BottomSheet.Title>행사유형</BottomSheet.Title>
       <div ref={refs.content} className="w-full pb-12 pt-8">
         {EVENTS.map((event) => (
-          <EventButton onClick={() => handleClick(event)} selected={selected === event}>
+          <EventButton onClick={() => handleClick(event)} selected={selected === event} key={event}>
             {event}
           </EventButton>
         ))}

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -24,6 +24,10 @@ interface Props {
 const HorizontalEventCard = ({ data, onHeartClick, isGrow = false, isMypage = false, setDep }: Props) => {
   const formattedDate = formatDate(data.startDate, data.endDate);
   const formattedAddress = formatAddress(data.address);
+  const formattedTagsMobile = data.eventTags.sort((a, b) => TAG_ORDER[a.tagName] - TAG_ORDER[b.tagName]).slice(0, 5);
+  const extraTagNumberMobile = data.eventTags.length - 5 > 0 ? data.eventTags.length - 5 : 0;
+  const formattedTagsPc = data.eventTags.sort((a, b) => TAG_ORDER[a.tagName] - TAG_ORDER[b.tagName]).slice(0, 8);
+  const extraTagNumberPc = data.eventTags.length - 8 > 0 ? data.eventTags.length - 8 : 0;
 
   const { liked, likeCount, handleLikeEvent } = useLikeEvent({ eventId: data.id, initialLike: data.isLike, initialLikeCount: data.likeCount });
 
@@ -84,12 +88,17 @@ const HorizontalEventCard = ({ data, onHeartClick, isGrow = false, isMypage = fa
             <span className="mr-8 border-r border-gray-400 pr-8">{formattedDate}</span>
             <span>{formattedAddress}</span>
           </p>
-          <ul className="flex flex-wrap gap-4">
-            {data.eventTags
-              .sort((a, b) => TAG_ORDER[a.tagName] - TAG_ORDER[b.tagName])
-              .map((tag) => (
-                <Chip key={tag.tagId} kind="goods" label={tag.tagName} />
-              ))}
+          <ul className="flex flex-wrap items-center gap-4 pc:hidden">
+            {formattedTagsMobile.map((tag) => (
+              <Chip key={tag.tagId} kind="goods" label={tag.tagName} />
+            ))}
+            {!!extraTagNumberMobile && <span className="text-center text-12 font-600 text-gray-700">{`외 ${extraTagNumberMobile}개`}</span>}
+          </ul>
+          <ul className="hidden flex-wrap items-center gap-4 pc:flex">
+            {formattedTagsPc.map((tag) => (
+              <Chip key={tag.tagId} kind="goods" label={tag.tagName} />
+            ))}
+            {!!extraTagNumberPc && <span className="text-center text-12 font-600 text-gray-700">{`외 ${extraTagNumberPc}개`}</span>}
           </ul>
         </div>
       </div>

--- a/app/_components/card/HorizontalEventCard.tsx
+++ b/app/_components/card/HorizontalEventCard.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { SyntheticEvent, useState } from "react";
 import HeartButton from "@/components/button/HeartButton";
 import Chip from "@/components/chip/Chip";
-import { useBottomSheet } from "@/hooks/useBottomSheet";
+import useBottomSheet from "@/hooks/useBottomSheet";
 import useLikeEvent from "@/hooks/useLikeEvent";
 import { formatAddress, formatDate } from "@/utils/formatString";
 import { EventCardType } from "@/types/index";

--- a/app/_components/header/PcHeader.tsx
+++ b/app/_components/header/PcHeader.tsx
@@ -3,21 +3,19 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import SearchInput from "@/components/input/SearchInput";
+import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
 import { Session, getSession } from "@/store/session/cookies";
 import AddIcon from "@/public/icon/add.svg";
 import LogoIcon from "@/public/icon/logo.svg";
+import SearchIcon from "@/public/icon/search.svg";
 
 const DEFAULT_PROFILE_SRC = "/icon/no-profile.svg";
 
 const PcHeader = () => {
-  const router = useRouter();
   const newSession = getSession();
   const [session, setSession] = useState<Session>();
   const profileHref = session ? "/mypage" : "/signin";
   const profileSrc = session?.user.profileImage ?? DEFAULT_PROFILE_SRC;
-  const [keyword, setKeyword] = useState("");
 
   useEffect(() => {
     if (!newSession) {
@@ -27,13 +25,6 @@ const PcHeader = () => {
     setSession(newSession);
   }, [newSession?.user.profileImage]);
 
-  useEffect(() => {
-    if (!keyword) {
-      return;
-    }
-    router.push(`/search?sort=최신순&keyword=${keyword}`);
-  }, [keyword]);
-
   return (
     <header className="sticky top-0 z-popup hidden h-64 w-full border-b border-gray-50 bg-white-black px-24 py-12 tablet:block">
       <div className="mx-auto flex h-full max-w-[104rem] items-center justify-between">
@@ -41,9 +32,7 @@ const PcHeader = () => {
           <LogoIcon />
         </Link>
         <div className="flex items-center">
-          <div className="w-320">
-            <SearchInput setKeyword={setKeyword} placeholder="최애의 행사를 찾아보세요!" size="sm" href="/search?sort=최신순" />
-          </div>
+          <SearchInput />
           <Link href={"/post"} className="flex-center ml-20 mr-16 h-40 w-100 rounded-full bg-main-pink-500 text-14 font-600 text-white-black">
             <AddIcon stroke="#FFF" width={20} height={20} viewBox="0 0 24 24" />
             행사 등록
@@ -58,3 +47,33 @@ const PcHeader = () => {
 };
 
 export default PcHeader;
+
+const SearchInput = () => {
+  const [keyword, setKeyword] = useState("");
+  const router = useRouter();
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = e.target.value;
+    setKeyword(nextValue);
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    router.push(`/search?sort=최신순&keyword=${keyword}`);
+    setKeyword("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="relative">
+      <input
+        onChange={handleChange}
+        value={keyword}
+        placeholder="최애의 행사를 찾아보세요!"
+        className="h-44 w-320 rounded-full bg-gray-50 pl-16 pr-48 text-16 font-400 outline-none placeholder:text-gray-400"
+      />
+      <button className="absolute right-12 top-1/2 -translate-y-1/2">
+        <SearchIcon width="20" height="20" stroke="#494F5A" />
+      </button>
+    </form>
+  );
+};

--- a/app/_components/input/SearchInput.tsx
+++ b/app/_components/input/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Dispatch, SetStateAction, useEffect } from "react";
 import { KeyboardEvent } from "react";
 import { useForm } from "react-hook-form";
@@ -10,11 +10,9 @@ interface Props {
   setKeyword: Dispatch<SetStateAction<string>>;
   initialKeyword?: string;
   placeholder?: string;
-  size?: "lg" | "sm";
-  href?: string;
 }
 
-const SearchInput = ({ keyword, setKeyword, initialKeyword, href, placeholder = "검색어를 입력하세요.", size = "lg" }: Props) => {
+const SearchInput = ({ keyword, setKeyword, initialKeyword, placeholder = "검색어를 입력하세요." }: Props) => {
   const { register, getValues, setValue, watch } = useForm({
     defaultValues: {
       search: initialKeyword,
@@ -29,13 +27,8 @@ const SearchInput = ({ keyword, setKeyword, initialKeyword, href, placeholder = 
     }
   };
 
-  const router = useRouter();
   const handleSearchClick = () => {
     const newKeyword = getValues("search") ?? "";
-    if (!newKeyword && href) {
-      router.push(href);
-    }
-
     setKeyword(newKeyword);
   };
 
@@ -60,17 +53,17 @@ const SearchInput = ({ keyword, setKeyword, initialKeyword, href, placeholder = 
     <div className="relative">
       <input
         autoFocus={curPath === "/post" || curPath === "/edit"}
-        className={`h-44 w-full rounded-full bg-gray-50 px-16 py-12 pr-68 text-16 text-black-white placeholder:text-gray-400 focus:outline-none ${size === "lg" ? "pc:h-52 pc:border pc:border-gray-100 pc:bg-white-black" : ""} pc:px-20 pc:pr-76`}
+        className="h-44 w-full rounded-full bg-gray-50 px-16 py-12 pr-68 text-16 text-black-white placeholder:text-gray-400 focus:outline-none pc:h-52 pc:border pc:border-gray-100 pc:bg-white-black pc:px-20 pc:pr-76"
         placeholder={placeholder}
         {...register("search")}
         onKeyDown={handleSearchEnter}
         autoComplete="off"
       />
-      <button className={`flex-center absolute right-12 top-4 h-36 w-36 rounded-full bg-gray-50 ${size === "lg" ? "pc:top-8" : ""}`} type="button" onClick={handleSearchClick}>
+      <button className="flex-center absolute right-12 top-4 h-36 w-36 rounded-full bg-gray-50 pc:top-8" type="button" onClick={handleSearchClick}>
         <SearchIcon width="20" height="20" stroke="#494F5A" />
       </button>
       {search && (
-        <button className={`absolute right-48 top-[1.4rem] pc:right-56 ${size === "lg" ? "pc:top-[1.8rem]" : ""}`} type="button" onClick={handleCloseClick}>
+        <button className="absolute right-48 top-[1.4rem] pc:right-56 pc:top-[1.8rem]" type="button" onClick={handleCloseClick}>
           <CloseIcon stroke="#A0A5B1" width="16" height="16" />
         </button>
       )}

--- a/app/_hooks/useBottomSheet.tsx
+++ b/app/_hooks/useBottomSheet.tsx
@@ -9,7 +9,7 @@ interface BottomSheetMetrics {
   isContentAreaTouched: boolean;
 }
 
-export function useBottomSheet() {
+const useBottomSheet = () => {
   const [bottomSheet, setBottomSheet] = useState("");
 
   const openBottomSheet = (type: string) => {
@@ -99,4 +99,6 @@ export function useBottomSheet() {
   }, [bottomSheet]);
 
   return { bottomSheet, openBottomSheet, closeBottomSheet, refs };
-}
+};
+
+export default useBottomSheet;

--- a/app/_hooks/useCustomMap.tsx
+++ b/app/_hooks/useCustomMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import { EventCardType } from "@/types/index";
 
 const useCustomMap = () => {
@@ -44,3 +44,16 @@ const useCustomMap = () => {
 };
 
 export default useCustomMap;
+
+export interface MapVarType {
+  toggleTab: boolean;
+  setToggleTab: Dispatch<SetStateAction<boolean>>;
+  selectedCard: EventCardType | null;
+  setSelectedCard: Dispatch<SetStateAction<EventCardType | null>>;
+}
+
+export interface MapCallbackType {
+  handleCardClick: (select: EventCardType) => void;
+  handleButtonClick: () => void;
+  scrollRefCallback: (el: HTMLDivElement) => void;
+}


### PR DESCRIPTION
## ✏️ 변경사항
- 아티스트 페이지에서 모바일 화면일 때 보이는 바텀시트의 드래그 기능을 구현했습니다.
- 사소한 디자인들을 수정했습니다.

## 📷 스크린샷

https://github.com/P1Z7/frontend/assets/83965026/4684c7bd-2110-41aa-9c46-fd0ce2e7e375


